### PR TITLE
Document deterministic example workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,54 @@
 # Realistic MLB Game Simulator
 
-## Project Goal
+This repository contains a command line play-by-play simulator that aims to produce logs that feel indistinguishable from a real Major League Baseball broadcast. The engine models pitch-by-pitch sequences, strategic bullpen usage, and situational events (mound visits, defensive alignments, challenges, weather, etc.) to generate rich narration while respecting modern MLB rules.
 
-This command-line tool simulates a complete, realistic Major League Baseball game. The primary goal is to create a simulation that is indistinguishable from a real-game play-by-play log, adhering closely to the rules, strategies, and nuances of modern professional baseball.
+## Getting Started
 
-The simulation moves beyond simple probability, incorporating a pitch-by-pitch at-bat sequence, dynamic pitcher fatigue, and strategic bullpen management to generate a plausible and engaging game narrative.
+### Requirements
 
-## Core Features for Realism
+* Python 3.9 or newer
 
-To achieve a high level of authenticity, the simulator implements the following key features:
+Install the Python dependencies (only the standard library is required) and run the simulator directly:
 
-* **Modern MLB Ruleset:** The simulation strictly follows current MLB rules, including:
-    * **The Designated Hitter (DH):** Pitchers do not bat; a DH is used in the lineup for both teams.
-    * **Extra-Innings "Ghost Runner":** Starting from the 10th inning, each half-inning automatically begins with a runner on second base to mirror modern pace-of-play rules.
-* **Pitch-by-Pitch Simulation:** Every at-bat unfolds one pitch at a time. The engine logs the pitch type, location (in or out of the strike zone), and the outcome (ball, called strike, swinging strike, foul, or in-play), providing a granular and realistic play-by-play.
-* **Dynamic Bullpen Management:** Starting pitchers operate on a stamina system based on pitch counts. Once fatigued, the simulation's logic makes a strategic pitching change, selecting an appropriate reliever (Long Reliever, Middle Reliever, or Closer) from the bullpen based on the game situation.
-* **Detailed Player Attributes:** All players are defined by specific attributes that influence their performance, including:
-    * **Batting statistics** for various hit types.
-    * **Batter handedness** (Left, Right, or Switch).
-    * **Pitcher handedness**, individual **pitch arsenals** (e.g., Fastball, Slider, Curveball), and a **control** rating.
-* **Fictional Rosters:** To ensure a unique experience, the simulator uses entirely fictional teams and players, allowing the focus to remain on the quality of the simulation itself.
+```bash
+python baseball.py
+```
 
-## How to Run
+Use the available CLI flags to tailor the narration style:
 
-1.  Ensure you have Python installed.
-2.  Save both `baseball_simulator.py` and `teams.py` in the same directory.
-3.  Open your terminal or command prompt, navigate to that directory, and run the following command:
-    ```
-    python baseball_simulator.py
-    ```
-The simulation will start immediately and print the full game log to the console.
+* `--terse` – switch to the more compact play-by-play phrasing that mirrors data feeds.
+* `--bracketed-ui` – render base runner state using legacy bracketed indicators instead of prose.
 
-## Technical Design
+### Running the Test Suite
 
-The project is split into two main files for modularity and ease of customization:
+The project ships with a growing collection of regression tests that encode previously observed realism issues. Run everything with:
 
-* **`baseball_simulator.py`**: The core simulation engine containing all the game logic, rules, and state management.
-* **`teams.py`**: A data file that defines the rosters, player names, positions, and statistical probabilities. You can easily edit this file to create your own custom teams and players without altering the simulation logic.
+```bash
+pytest -q
+```
+
+The tests cover items such as bullpen variability, pitch vocabulary diversity, realistic catcher groundout frequencies, and snapshot comparisons against curated example games.
+
+## Deterministic Example Games
+
+The `examples/` directory tracks ten seeded, deterministic game logs. These files are used both for documentation and for regression testing to ensure that engine changes produce intentional differences.
+
+* `example_games.py` defines the `ExampleGame` helper along with the catalog of seeds.
+* `test_examples_snapshot.py` renders each game with a fixed seed and asserts that the generated output matches the stored text files.
+* `update_examples.py` provides a convenient way to refresh the tracked examples after making a behavior change:
+
+  ```bash
+  python update_examples.py
+  ```
+
+  The script will re-render every example using the latest simulator behavior so the new output can be reviewed and committed alongside your code changes.
+
+## Project Structure
+
+* `baseball.py` – core simulation engine and CLI entry point.
+* `teams.py` – fictional rosters, player attributes, and ambient context (umpires, weather, venues).
+* `example_games.py` – deterministic example definitions used for snapshot testing and documentation.
+* `examples/` – checked-in play-by-play logs generated from fixed seeds.
+* `test_*.py` – pytest suites that enforce realism constraints and snapshot parity.
+
+Feel free to modify the team definitions or extend the rules engine. When adding new realism features, remember to regenerate the example logs and expand the regression tests where appropriate so we continue guarding against past issues resurfacing.

--- a/example_games.py
+++ b/example_games.py
@@ -1,0 +1,66 @@
+"""Utilities for managing deterministic example game logs."""
+from __future__ import annotations
+
+import copy
+import io
+import random
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from baseball import BaseballSimulator
+from teams import TEAMS
+
+
+_BASE_TEAMS = {key: copy.deepcopy(value) for key, value in TEAMS.items()}
+
+
+EXAMPLES_DIR = Path(__file__).parent / "examples"
+
+
+@dataclass(frozen=True)
+class ExampleGame:
+    seed: int
+    home_team: str = "BAY_BOMBERS"
+    away_team: str = "PC_PILOTS"
+    verbose_phrasing: bool = True
+    use_bracketed_ui: bool = False
+
+    def render(self) -> str:
+        """Render the play-by-play log for this example game."""
+        random.seed(self.seed)
+        simulator = BaseballSimulator(
+            copy.deepcopy(_BASE_TEAMS[self.home_team]),
+            copy.deepcopy(_BASE_TEAMS[self.away_team]),
+            verbose_phrasing=self.verbose_phrasing,
+            use_bracketed_ui=self.use_bracketed_ui,
+        )
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            simulator.play_game()
+        return buffer.getvalue()
+
+
+EXAMPLE_GAMES: List[ExampleGame] = [
+    ExampleGame(seed=101),
+    ExampleGame(seed=202),
+    ExampleGame(seed=303),
+    ExampleGame(seed=404),
+    ExampleGame(seed=505),
+    ExampleGame(seed=606),
+    ExampleGame(seed=707),
+    ExampleGame(seed=808),
+    ExampleGame(seed=909),
+    ExampleGame(seed=1001),
+]
+
+
+def iter_example_paths(games: Iterable[ExampleGame] | None = None):
+    """Yield the path for each example game file."""
+    games = list(EXAMPLE_GAMES if games is None else games)
+    for index, _ in enumerate(games, start=1):
+        yield EXAMPLES_DIR / f"game_{index:02d}.txt"
+
+
+__all__ = ["ExampleGame", "EXAMPLE_GAMES", "EXAMPLES_DIR", "iter_example_paths"]

--- a/examples/game_01.txt
+++ b/examples/game_01.txt
@@ -1,0 +1,610 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 72°F, Partly Cloudy, Wind 10 mph L to R
+Umpires: HP: Gus Morales, 1B: Chuck Thompson, 2B: Frank Rizzo, 3B: Stan Friedman
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.9 mph), a perfect strike. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.6 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.3 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.3 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Slider (87.5 mph), low and away. Ball. Count: 1-1
+  Pitch: Changeup (83.9 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Changeup (83.0 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Alex Chase, 1B: Omar Ramirez | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (96.9 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Curveball (79.4 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (94.6 mph), freezes him on the inner edge. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Changeup (81.7 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (78.9 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.4 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 3B: Omar Ramirez, 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (95.6 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Rex Power, 2B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Curveball (78.2 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 3B: Rex Power, 2B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (79.3 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.7 mph), right down the middle. Called Strike. Count: 0-2
+  Pitch: Curveball (80.0 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (91.6 mph), catches the black. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.1 mph), high and tight. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.9 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (90.9 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.5 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (78.7 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Slider (86.2 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Slider (84.8 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (92.6 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Leo Vance, 1B: Sam Decker | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (92.0 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Curveball (78.9 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.9 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.3 mph), high and tight. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.0 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (87.0 mph), catches the black. Foul. Count: 0-1
+  Pitch: Slider (89.6 mph), high and tight. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.8 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (87.0 mph), catches the black. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Chops a bouncer toward the infield.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (91.3 mph), in the dirt. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (78.9 mph), sails over the letters. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (90.2 mph), in the zone. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (92.2 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (91.3 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.0 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (90.9 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 3B: Nate Diaz, 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (92.1 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (91.1 mph), way outside. Ball. Count: 1-0
+  Pitch: Curveball (78.9 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (79.6 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Slider (85.1 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (91.4 mph), sails over the letters. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.7 mph), high and tight. Ball. Count: 1-0
+  Pitch: Changeup (82.0 mph), in the dirt. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (88.2 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (89.8 mph), way outside. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Omar Ramirez | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (83.3 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Slider (89.0 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Curveball (80.2 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.1 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Changeup (83.6 mph), high and tight. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 3B: Omar Ramirez, 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Changeup (81.4 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Slider (88.9 mph), in the zone. Lifts a routine fly ball.
+  Sacrifice fly to RF, Omar Ramirez scores!
+Result: Flyout to RF (F9 (SF)) | Outs: 2 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (95.0 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (91.4 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.3 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Curveball (79.0 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (85.3 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (85.4 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Curveball (80.4 mph), low and away. Ball. Count: 3-0
+  Pitch: Two-Seam Fastball (90.3 mph), catches the black. Foul. Count: 3-1
+  Pitch: Slider (84.2 mph), a bit inside. Ball.
+Result: Walk         | Outs: 1 | Bases: 1B: Sam Decker | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.4 mph), in the dirt. Swinging Strike. Count: 0-1
+  Pitch: Curveball (81.0 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.3 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (90.8 mph), freezes him on the inner edge. Foul. Count: 2-2
+  Pitch: Two-Seam Fastball (91.0 mph), high and tight. Ball. Count: 3-2
+  Pitch: Curveball (80.0 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 1 | Bases: 2B: Sam Decker, 1B: Jackson Riley | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (91.0 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (85.0 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Sam Decker, 2B: Jackson Riley | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (86.3 mph), sails over the letters. Foul. Count: 0-1
+  Pitch: Slider (84.7 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.8 mph), in the zone. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 3B: Sam Decker, 2B: Jackson Riley | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (89.3 mph), right down the middle. Lifts a routine fly ball.
+  An error by RF Marcus Thorne allows the batter to reach base.
+Result: Reached on Error (E9) | Outs: 0 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (87.6 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.5 mph), catches the black. Foul. Count: 1-1
+  Pitch: Changeup (82.6 mph), in the zone. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 1 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (95.1 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.7 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.4 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Wes Griffin | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (97.0 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Slider (89.7 mph), catches the black. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 4
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Changeup (82.6 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Slider (88.3 mph), high and tight. Ball. Count: 1-1
+  Pitch: Curveball (80.8 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 4
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (91.2 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.2 mph), high and tight. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (91.8 mph), freezes him on the inner edge. Swinging Strike. Count: 2-1
+  Pitch: Curveball (78.5 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Curveball (80.3 mph), way outside. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (92.7 mph), way outside. Ball.
+Result: Walk         | Outs: 0 | Bases: 1B: Owen Chen | Score: Bay Area Bombers: 2, Pacific City Pilots: 4
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (90.3 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (78.7 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (92.7 mph), in the zone. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (92.6 mph), catches the black. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 1B: Owen Chen | Score: Bay Area Bombers: 2, Pacific City Pilots: 4
+
+Now batting: Grant Fisher (LF, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (84.6 mph), right down the middle. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (86.1 mph), catches the black. Foul. Count: 0-1
+  Pitch: Curveball (78.9 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+Now batting: Marcus Thorne (RF, L)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Slider (86.0 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.0 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Curveball (80.4 mph), high and tight. Ball. Count: 1-2
+  Pitch: Curveball (79.2 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Slider (84.8 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Pop out to 3B (P5) | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.8 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (80.4 mph), way outside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.1 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Slider (84.2 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (94.2 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.1 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.2 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 4, Pacific City Pilots: 4
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Changeup (83.7 mph), paints the corner. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (83.9 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Curveball (79.0 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.0 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Changeup (83.7 mph), in the zone. Swinging Strike. Count: 2-2
+  Pitch: Slider (88.0 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (94.5 mph), right down the middle. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (88.9 mph), snaps over the backdoor. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.4 mph), in the zone. Foul. Count: 0-2
+  Pitch: Curveball (79.5 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (81.7 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.1 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Curveball (81.4 mph), in the zone. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (81.9 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Curveball (81.2 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.0 mph), in the zone. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.0 mph), in the zone. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (95.9 mph), low and away. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (94.1 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.0 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.9 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.3 mph), right down the middle. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (95.5 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 3B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (89.3 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Changeup (83.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.5 mph), catches the black. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.7 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.2 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.8 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Curveball (78.5 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (79.2 mph), just misses outside. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Changeup (82.5 mph), way outside. Ball. Count: 2-0
+  Pitch: Slider (89.9 mph), in the dirt. Ball. Count: 3-0
+  Pitch: Four-Seam Fastball (95.4 mph), paints the corner. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (82.3 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.4 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.2 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (95.2 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (80.6 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.7 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (95.2 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), paints the corner. Called Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (93.7 mph), snaps over the backdoor. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (93.0 mph), drops onto the knees. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (95.6 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.0 mph), spikes before the plate. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (95.8 mph), snaps over the backdoor. Swinging Strike. Count: 2-1
+  Pitch: Curveball (80.0 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (95.8 mph), catches the black. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.3 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), high and tight. Ball. Count: 2-0
+  Pitch: Slider (87.2 mph), low and away. Ball. Count: 3-0
+  Pitch: Changeup (81.2 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (94.6 mph), catches the black. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.0 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 2B: Hank Barrett, 1B: Wes Griffin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Knuckle-Curve (77.8 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (77.3 mph), way outside. Ball. Count: 1-1
+  Pitch: Knuckle-Curve (78.2 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.6 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: 3B: Hank Barrett, 2B: Wes Griffin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Alex Chase (2B, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Four-Seam Fastball (94.3 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (79.5 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (92.9 mph), sails over the letters. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.4 mph), spikes before the plate. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 3B: Hank Barrett, 2B: Wes Griffin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.4 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (77.5 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.7 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (93.3 mph), way outside. Ball. Count: 2-2
+  Pitch: Knuckle-Curve (78.6 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 3B: Hank Barrett, 2B: Wes Griffin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (79.4 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.5 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Four-Seam Fastball (93.1 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (80.9 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Curveball (79.9 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (95.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.7 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (93.5 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (96.0 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (79.7 mph), paints the corner. Swinging Strike. Count: 0-2
+  Pitch: Curveball (80.2 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Knuckle-Curve (78.9 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.3 mph), sails over the letters. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Knuckle-Curve (79.1 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.6 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Knuckle-Curve (77.6 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (94.5 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 3B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (93.5 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (77.5 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 3B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Curveball (80.6 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.2 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (93.3 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.5 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (93.2 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.1 mph), in the dirt. Foul. Count: 0-2
+  Pitch: Curveball (81.2 mph), in the zone. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (80.0 mph), spikes before the plate. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 2B: Grant Fisher | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (95.5 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Curveball (80.6 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Grant Fisher | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Marcus Thorne (RF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (95.1 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.2 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 3B: Grant Fisher | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (79.6 mph), a perfect strike. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Wes Griffin (SS, S)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Knuckle-Curve (80.0 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (79.0 mph), catches the black. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 3B: Hank Barrett, 1B: Wes Griffin | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Sinker (91.7 mph), catches the black. Lifts a routine fly ball.
+Result: Pop out to SS (P6) | Outs: 1 | Bases: 3B: Hank Barrett, 1B: Wes Griffin | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Sinker (92.1 mph), paints the corner. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 3B: Wes Griffin, 2B: Alex Chase | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Sinker (92.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Sinker (91.8 mph), right down the middle. Called Strike. Count: 1-1
+  Pitch: Sinker (91.6 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Sinker (93.3 mph), in the dirt. Ball. Count: 3-1
+  Pitch: Sinker (93.4 mph), drops onto the knees. Foul. Count: 3-2
+  Pitch: Sinker (92.5 mph), paints the corner. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 3B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 6, Pacific City Pilots: 10
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Sinker (93.2 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 6, Pacific City Pilots: 11
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (92.8 mph), way outside. Ball. Count: 1-0
+  Pitch: Sinker (91.8 mph), in the zone. Foul. Count: 1-1
+  Pitch: Sinker (92.5 mph), snaps over the backdoor. Called Strike. Count: 1-2
+  Pitch: Sinker (91.6 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Kevin Webb, 1B: Rex Power | Score: Bay Area Bombers: 6, Pacific City Pilots: 11
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Sinker (93.5 mph), low and away. Ball. Count: 1-0
+  Pitch: Sinker (93.0 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 3B: Rex Power, 2B: Evan Reed | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (87.2 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (86.2 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Sinker (93.7 mph), snaps over the backdoor. Lifts a routine fly ball.
+Result: Pop out to 1B (P3) | Outs: 3 | Bases: 3B: Rex Power, 2B: Evan Reed | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (95.2 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (80.4 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.8 mph), catches the black. Hooks a double down the line!
+Result: Double       | Outs: 1 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (95.6 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Curveball (79.9 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.4 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+
+--- Pitching Change for Pacific City Pilots: Rollie Malone replaces Ben Logan ---
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Sinker (90.9 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 3B: Jackson Riley, 1B: Nate Diaz | Score: Bay Area Bombers: 6, Pacific City Pilots: 12
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (86.1 mph), catches the black. Foul. Count: 0-1
+  Pitch: Sinker (92.9 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Slider (85.2 mph), snaps over the backdoor. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 12
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Sinker (90.6 mph), in the zone. Foul. Count: 0-1
+  Pitch: Sinker (91.6 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Sinker (91.6 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Slider (87.1 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 12
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 9 - Pacific City Pilots 12
+
+Pacific City Pilots win!

--- a/examples/game_02.txt
+++ b/examples/game_02.txt
@@ -1,0 +1,528 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 75°F, Clear
+Umpires: HP: Gus Morales, 1B: Larry Phillips, 2B: Chuck Thompson, 3B: Stan Friedman
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.6 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.4 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Changeup (82.5 mph), in the dirt. Ball. Count: 1-2
+  Pitch: Changeup (81.1 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.9 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (87.0 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.9 mph), low and away. Ball. Count: 2-0
+  Pitch: Slider (89.9 mph), catches the black. Foul. Count: 2-1
+  Pitch: Four-Seam Fastball (96.6 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (95.7 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (91.1 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Slider (84.5 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (85.8 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.1 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (91.5 mph), low and away. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.3 mph), paints the corner. Called Strike. Count: 1-1
+  Pitch: Curveball (78.6 mph), freezes him on the inner edge. Called Strike. Count: 1-2
+  Pitch: Curveball (79.7 mph), freezes him on the inner edge. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Sam Decker | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.0 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Slider (85.2 mph), in the zone. Called Strike. Count: 1-1
+  Pitch: Curveball (79.0 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Curveball (78.4 mph), snaps over the backdoor. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 3B: Sam Decker, 2B: Jackson Riley | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.8 mph), low and away. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 3B: Sam Decker, 2B: Jackson Riley | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (89.1 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Changeup (82.8 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Curveball (79.8 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Changeup (83.1 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Slider (88.3 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Changeup (83.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Ball. Count: 2-0
+  Pitch: Slider (87.7 mph), snaps over the backdoor. Foul. Count: 2-1
+  Pitch: Four-Seam Fastball (95.1 mph), spikes before the plate. Foul. Count: 2-2
+  Pitch: Slider (89.6 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Slider (89.0 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Curveball (79.3 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.3 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.3 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (78.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.8 mph), in the zone. Called Strike. Count: 1-1
+  Pitch: Curveball (81.0 mph), in the zone. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.4 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (91.8 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Curveball (78.6 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Slider (84.3 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (90.7 mph), a bit inside. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (90.4 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 3B: Nate Diaz | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (91.2 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.5 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), high and tight. Ball. Count: 2-1
+  Pitch: Curveball (80.8 mph), way outside. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (92.0 mph), catches the black. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (90.7 mph), just misses outside. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.0 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Curveball (79.7 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Slider (86.5 mph), a perfect strike. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (91.8 mph), way outside. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (92.9 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (96.3 mph), high and tight. Swinging Strike. Count: 0-1
+  Pitch: Slider (87.9 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Slider (88.9 mph), way outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (96.3 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Slider (89.9 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (88.8 mph), drops onto the knees. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (95.5 mph), just misses outside. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.3 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.3 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.1 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Curveball (79.5 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Changeup (81.8 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (97.0 mph), low and away. Ball. Count: 3-1
+  Pitch: Four-Seam Fastball (95.4 mph), just misses outside. Ball.
+Result: Walk         | Outs: 2 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (94.8 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.2 mph), sails over the letters. Ball. Count: 2-0
+  Pitch: Changeup (81.4 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Alex Chase, 2B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (82.8 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), in the zone. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 3B: Kevin Webb, 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (95.7 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 3B: Kevin Webb, 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.7 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Slider (85.3 mph), catches the black. Foul. Count: 1-1
+  Pitch: Slider (84.1 mph), drops onto the knees. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (78.1 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.9 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (85.2 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.5 mph), low and away. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.4 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.1 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Pop out to 2B (P4) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (94.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.4 mph), a perfect strike. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.9 mph), freezes him on the inner edge. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (83.2 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Changeup (81.7 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.5 mph), high and tight. Ball. Count: 2-1
+  Pitch: Curveball (80.1 mph), a bit inside. Ball. Count: 3-1
+  Pitch: Four-Seam Fastball (94.7 mph), freezes him on the inner edge. Called Strike. Count: 3-2
+  Pitch: Four-Seam Fastball (94.7 mph), catches the black. Chops a bouncer toward the infield.
+  An error by SS Caleb Jones allows the batter to reach base.
+Result: Reached on Error (E6) | Outs: 0 | Bases: 3B: Felix Washington, 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Curveball (78.3 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.2 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.9 mph), low and away. Ball. Count: 2-1
+  Pitch: Changeup (81.5 mph), in the zone. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (94.6 mph), in the dirt. Skies it to the outfield.
+  Sacrifice fly to CF, Felix Washington scores!
+Result: Flyout to CF (F8 (SF)) | Outs: 1 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (95.9 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (78.0 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Slider (87.2 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Hank Barrett, 1B: Alex Chase | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (88.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 3B: Hank Barrett, 1B: Alex Chase | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.5 mph), snaps over the backdoor. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Quick throw to first and Nate Diaz dives back safely.
+  Pitch: Slider (86.9 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (79.6 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Miles Corbin (3B, S)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (80.8 mph), snaps over the backdoor. Called Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.3 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Grant Fisher (LF, R)
+  Defensive alignment: Outfield shifts toward right-center.
+  Pitch: Two-Seam Fastball (91.2 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Curveball (80.6 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (91.6 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (92.8 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.3 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (89.6 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (87.3 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (86.1 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (92.6 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Curveball (79.2 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (90.8 mph), catches the black. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.7 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.8 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (91.4 mph), a bit inside. Ball. Count: 3-1
+  Pitch: Slider (84.5 mph), in the zone. Foul. Count: 3-2
+  Pitch: Two-Seam Fastball (91.6 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (90.1 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (79.1 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Slider (84.3 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (92.5 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Slider (84.9 mph), a perfect strike. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.9 mph), in the dirt. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.7 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Slider (84.5 mph), catches the black. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (95.6 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (79.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (96.6 mph), drops onto the knees. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.6 mph), low and away. Ball. Count: 2-2
+  Pitch: Slider (90.0 mph), high and tight. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Curveball (80.7 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.9 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Slider (87.9 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.4 mph), way outside. Ball. Count: 2-1
+  Pitch: Slider (88.4 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Slider (85.2 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Curveball (80.6 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (95.2 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (79.2 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (93.3 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Pop out to SS (P6) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Joe Gibson ---
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Sinker (92.1 mph), way outside. Ball. Count: 1-0
+  Pitch: Sinker (91.4 mph), catches the black. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Sinker (93.5 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Sinker (92.4 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Sinker (93.0 mph), spikes before the plate. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (87.3 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Sinker (93.9 mph), snaps over the backdoor. Swinging Strike. Count: 1-1
+  Pitch: Sinker (91.3 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (86.9 mph), a perfect strike. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (96.0 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (81.3 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.0 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Pop out to 1B (P3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (79.7 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.5 mph), spikes before the plate. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (93.6 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (81.7 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Sinker (92.3 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Sinker (92.2 mph), paints the corner. Swinging Strike. Count: 0-2
+  Pitch: Slider (87.9 mph), low and away. Ball. Count: 1-2
+  Pitch: Sinker (93.3 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Slider (87.7 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 4
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (86.0 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (87.9 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Sinker (92.2 mph), right down the middle. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (91.9 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Slider (87.9 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Sinker (91.8 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Sinker (92.1 mph), paints the corner. Foul. Count: 1-1
+  Pitch: Slider (86.1 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Sinker (93.5 mph), a perfect strike. Swinging Strike. Count: 2-2
+  Pitch: Sinker (91.6 mph), drops onto the knees. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 3B: Felix Washington, 2B: Hank Barrett | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Sinker (93.4 mph), spikes before the plate. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 2 | Bases: 3B: Felix Washington, 2B: Hank Barrett | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Sinker (93.9 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 3B: Felix Washington, 2B: Hank Barrett | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (94.0 mph), drops onto the knees. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (81.4 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.5 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Curveball (79.7 mph), freezes him on the inner edge. Called Strike. Count: 1-2
+  Pitch: Curveball (80.0 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (93.4 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), just misses outside. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.3 mph), catches the black. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.2 mph), snaps over the backdoor. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.8 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.1 mph), high and tight. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Jackson Riley | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (94.1 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.8 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (93.7 mph), snaps over the backdoor. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (94.4 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.2 mph), way outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.1 mph), just misses outside. Ball. Count: 2-1
+  Pitch: Curveball (80.0 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (86.5 mph), way outside. Swinging Strike. Count: 0-1
+  Pitch: Sinker (93.0 mph), spikes before the plate. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+Result: Hit by Pitch | Outs: 1 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Sinker (91.8 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Slider (86.4 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Sinker (92.3 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 3B: Kevin Webb, 2B: Omar Ramirez | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (93.2 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.8 mph), paints the corner. Skies it to the outfield.
+  Sacrifice fly to RF, Kevin Webb scores!
+Result: Flyout to RF (F9 (SF)) | Outs: 2 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (86.8 mph), freezes him on the inner edge. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 6, Pacific City Pilots: 7
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (92.8 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Slider (88.0 mph), right down the middle. Swinging Strike. Count: 0-2
+  Pitch: Slider (87.8 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Slider (86.9 mph), just misses outside. Ball. Count: 2-2
+  Pitch: Slider (87.0 mph), paints the corner. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Sinker (93.5 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (95.6 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Curveball (81.0 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Curveball (80.1 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (81.8 mph), low and away. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (81.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.6 mph), spikes before the plate. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 9
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 6 - Pacific City Pilots 9
+
+Pacific City Pilots win!

--- a/examples/game_03.txt
+++ b/examples/game_03.txt
@@ -1,0 +1,528 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 72°F, Partly Cloudy, Wind 10 mph L to R
+Umpires: HP: Larry Phillips, 1B: Chuck Thompson, 2B: Frank Rizzo, 3B: Stan Friedman
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Changeup (83.5 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.8 mph), sails over the letters. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.0 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.7 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.9 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Slider (89.6 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (96.8 mph), a perfect strike. Called Strike. Count: 2-2
+  Pitch: Curveball (79.9 mph), just misses outside. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.6 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.5 mph), catches the black. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.5 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.1 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Slider (89.7 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Curveball (80.1 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Changeup (81.8 mph), in the zone. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (96.8 mph), paints the corner. Swinging Strike. Count: 1-2
+  Pitch: Changeup (83.0 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (86.6 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (79.5 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (91.7 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.2 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (92.6 mph), a perfect strike. Swinging Strike. Count: 1-2
+  Pitch: Curveball (78.3 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (78.9 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.2 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (95.3 mph), catches the black. Foul. Count: 0-1
+  Pitch: Changeup (83.5 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.4 mph), a bit inside. Ball. Count: 1-2
+  Pitch: Curveball (80.6 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (88.8 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Changeup (83.4 mph), a perfect strike. Foul. Count: 1-1
+  Pitch: Changeup (83.8 mph), in the zone. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.2 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (96.8 mph), way outside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), low and away. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Quick throw to first and Hank Barrett dives back safely.
+  Pitch: Four-Seam Fastball (94.2 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.3 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.0 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Slider (88.0 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Changeup (81.2 mph), in the zone. Foul. Count: 3-2
+  Pitch: Four-Seam Fastball (96.4 mph), right down the middle. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 2B: Hank Barrett, 1B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (88.5 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.2 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Changeup (81.2 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 2B: Hank Barrett, 1B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (90.0 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.7 mph), low and away. Ball. Count: 2-0
+  Pitch: Curveball (78.5 mph), right down the middle. Swinging Strike. Count: 2-1
+  Pitch: Two-Seam Fastball (92.6 mph), drops onto the knees. Skies it to the outfield.
+Result: Pop out to 2B (P4) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (91.1 mph), in the dirt. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (93.0 mph), high and tight. Foul. Count: 0-2
+  Pitch: Slider (86.8 mph), spikes before the plate. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (90.9 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (85.9 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.7 mph), in the zone. Foul. Count: 1-1
+  Pitch: Slider (85.1 mph), catches the black. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (91.4 mph), catches the black. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (94.4 mph), spikes before the plate. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (81.6 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.7 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.3 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (87.3 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (94.3 mph), low and away. Ball. Count: 3-0
+  Pitch: Four-Seam Fastball (96.1 mph), low and away. Ball.
+Result: Walk         | Outs: 2 | Bases: 1B: Omar Ramirez | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (87.2 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (80.1 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (96.9 mph), way outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (96.9 mph), a bit inside. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 1B: Omar Ramirez | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (86.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (85.4 mph), snaps over the backdoor. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (80.6 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Curveball (78.8 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (91.4 mph), low and away. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (90.7 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 0 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (80.6 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (78.2 mph), drops onto the knees. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.7 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.1 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Slider (85.3 mph), snaps over the backdoor. Swinging Strike. Count: 0-2
+  Pitch: Curveball (80.9 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.9 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (80.4 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (92.2 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Curveball (78.2 mph), snaps over the backdoor. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Miles Corbin, 1B: Marcus Thorne | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (90.5 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.5 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Curveball (80.7 mph), in the zone. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (90.1 mph), drops onto the knees. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 3B: Marcus Thorne, 2B: Sam Decker | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (81.0 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 3B: Marcus Thorne, 2B: Sam Decker | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (94.4 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Changeup (83.0 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.9 mph), high and tight. Ball. Count: 1-1
+  Pitch: Curveball (78.3 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Curveball (80.1 mph), freezes him on the inner edge. Called Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (94.3 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (82.6 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.4 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (91.8 mph), way outside. Ball. Count: 1-0
+  Pitch: Curveball (79.3 mph), spikes before the plate. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (92.3 mph), in the dirt. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (79.5 mph), low and away. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (90.4 mph), spikes before the plate. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (90.5 mph), high and tight. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (92.6 mph), high and tight. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (91.4 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Curveball (80.6 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Curveball (80.9 mph), way outside. Ball. Count: 1-0
+  Pitch: Curveball (79.3 mph), way outside. Ball. Count: 2-0
+  Pitch: Changeup (83.0 mph), a perfect strike. Foul. Count: 2-1
+  Pitch: Slider (87.7 mph), a perfect strike. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Changeup (82.3 mph), just misses outside. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (83.0 mph), a bit inside. Swinging Strike. Count: 0-1
+  Pitch: Changeup (83.0 mph), catches the black. Foul. Count: 0-2
+  Pitch: Slider (87.5 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (91.8 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (92.7 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.3 mph), snaps over the backdoor. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (90.5 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.5 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.6 mph), paints the corner. Foul. Count: 1-1
+  Pitch: Two-Seam Fastball (91.9 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (79.4 mph), drops onto the knees. Rolls it over on the ground.
+  An error by 1B Felix Washington allows the batter to reach base.
+Result: Reached on Error (E3) | Outs: 2 | Bases: 2B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (91.2 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.8 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Curveball (79.3 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (92.3 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.9 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (94.9 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.6 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.9 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.3 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (89.2 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.1 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (78.4 mph), a perfect strike. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Quick throw to first and Nate Diaz dives back safely.
+  Pitch: Curveball (79.0 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.7 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.7 mph), in the dirt. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (92.5 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (78.4 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.4 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Slider (86.8 mph), low and away. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (92.2 mph), high and tight. Ball. Count: 3-1
+  Pitch: Slider (86.3 mph), catches the black. Foul. Count: 3-2
+  Pitch: Curveball (79.9 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (94.4 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Slider (87.5 mph), way outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (96.8 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (95.4 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (83.2 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Curveball (79.0 mph), in the zone. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.8 mph), in the zone. Rolls it over on the ground.
+  An error by 2B Nate Diaz allows the batter to reach base.
+Result: Reached on Error (E4) | Outs: 1 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (94.2 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (92.8 mph), drops onto the knees. Chops a bouncer toward the infield.
+  Ground ball to second... 4-6-3 double play!
+Result: Groundout, Double Play (GDP (4-6-3)) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+
+--- Pitching Change for Pacific City Pilots: Rollie Malone replaces Miguel Garcia ---
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Slider (87.3 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Sinker (91.9 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Sinker (91.3 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Sinker (92.2 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Slider (85.1 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Sinker (90.4 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: 2B: Grant Fisher | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Sinker (92.9 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Sinker (90.1 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Sinker (92.6 mph), paints the corner. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 3B: Grant Fisher, 1B: Marcus Thorne | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (87.4 mph), in the zone. Foul. Count: 0-1
+  Pitch: Sinker (90.7 mph), high and tight. Ball. Count: 1-1
+  Pitch: Sinker (92.4 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 3B: Grant Fisher, 1B: Marcus Thorne | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Sinker (90.4 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 3B: Grant Fisher, 1B: Marcus Thorne | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Knuckle-Curve (77.7 mph), in the zone. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.0 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Knuckle-Curve (77.9 mph), high and tight. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (78.9 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (93.2 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (92.1 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (78.7 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (92.5 mph), high and tight. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (77.9 mph), snaps over the backdoor. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (92.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (77.2 mph), snaps over the backdoor. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (94.8 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Sinker (90.3 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Sinker (90.4 mph), right down the middle. Swinging Strike. Count: 0-2
+  Pitch: Sinker (91.0 mph), snaps over the backdoor. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Sinker (91.0 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Slider (86.2 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Sinker (90.8 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (85.4 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Sinker (91.7 mph), drops onto the knees. Swinging Strike. Count: 0-2
+  Pitch: Sinker (92.8 mph), a perfect strike. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (93.9 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (79.2 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.3 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (93.9 mph), in the zone. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (92.8 mph), way outside. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (92.4 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Knuckle-Curve (79.2 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.4 mph), in the zone. Swinging Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (92.6 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (94.5 mph), way outside. Ball.
+Result: Walk         | Outs: 0 | Bases: 3B: Rex Power, 2B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Knuckle-Curve (79.1 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (92.3 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (92.7 mph), freezes him on the inner edge. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 3B: Rex Power, 2B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Sinker (91.2 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Sinker (93.0 mph), low and away. Ball. Count: 1-1
+  Pitch: Slider (86.1 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Sinker (92.9 mph), high and tight. Ball. Count: 3-1
+  Pitch: Slider (86.0 mph), spikes before the plate. Ball.
+Result: Walk         | Outs: 1 | Bases: 3B: Evan Reed, 2B: Felix Washington, 1B: Wes Griffin | Score: Bay Area Bombers: 5, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (86.7 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.6 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (92.3 mph), paints the corner. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Sinker (93.7 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Sinker (92.7 mph), spikes before the plate. Ball. Count: 2-0
+  Pitch: Slider (87.3 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (88.0 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Sinker (91.8 mph), drops onto the knees. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 8
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (86.3 mph), in the zone. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (86.6 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Slider (86.4 mph), a perfect strike. Rolls it over on the ground.
+Result: Dribbler in front, catcher fields (2-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Pitch: Sinker (90.1 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Sinker (90.0 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Slider (85.2 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Sinker (91.6 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Sinker (92.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (91.2 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Sinker (90.8 mph), freezes him on the inner edge. Skies it to the outfield.
+  An error by LF Evan Reed allows the batter to reach base.
+Result: Reached on Error (E7) | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Sinker (91.7 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Dribbler in front, catcher fields (2-3) | Outs: 3 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 5, Pacific City Pilots: 9
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 5 - Pacific City Pilots 9
+
+Pacific City Pilots win!

--- a/examples/game_04.txt
+++ b/examples/game_04.txt
@@ -1,0 +1,555 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 68°F, Overcast
+Umpires: HP: Chuck Thompson, 1B: Stan Friedman, 2B: Frank Rizzo, 3B: Gus Morales
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (89.5 mph), paints the corner. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (87.8 mph), way outside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.3 mph), snaps over the backdoor. Swinging Strike. Count: 0-2
+  Pitch: Changeup (81.9 mph), a bit inside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (96.4 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (94.3 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Slider (88.7 mph), in the zone. Foul. Count: 0-2
+  Pitch: Slider (88.7 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.3 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (94.3 mph), drops onto the knees. Swinging Strike. Count: 2-1
+  Pitch: Four-Seam Fastball (96.7 mph), way outside. Ball. Count: 3-1
+  Pitch: Curveball (79.1 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Quick throw to first and Kevin Webb dives back safely.
+  Pitch: Changeup (82.8 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), paints the corner. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 3B: Kevin Webb, 2B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (87.7 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (89.2 mph), low and away. Skies it to the outfield.
+  An error by CF Leo Vance allows the batter to reach base.
+Result: Reached on Error (E8) | Outs: 2 | Bases: 3B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (96.0 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 3B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (90.3 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (90.6 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.9 mph), in the zone. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (85.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.1 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (84.5 mph), right down the middle. Chops a bouncer toward the infield.
+  An error by 3B Omar Ramirez allows the batter to reach base.
+Result: Reached on Error (E5) | Outs: 1 | Bases: 3B: Leo Vance, 1B: Sam Decker | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (80.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.5 mph), a perfect strike. Foul. Count: 1-1
+  Pitch: Curveball (81.0 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Curveball (80.0 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Pop out to 2B (P4) | Outs: 2 | Bases: 3B: Leo Vance, 1B: Sam Decker | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Slider (84.3 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 3B: Leo Vance, 1B: Sam Decker | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (88.4 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Slider (87.8 mph), low and away. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (95.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.4 mph), sails over the letters. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.9 mph), drops onto the knees. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (96.1 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Slider (89.1 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.7 mph), a perfect strike. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (92.6 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Slider (85.0 mph), high and tight. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.5 mph), high and tight. Ball. Count: 2-1
+  Pitch: Curveball (80.3 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.3 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Slider (85.1 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Slider (86.7 mph), catches the black. Foul. Count: 1-2
+  Pitch: Curveball (78.4 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (84.2 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (80.2 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.3 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), right down the middle. Swinging Strike. Count: 0-2
+  Pitch: Slider (89.5 mph), in the dirt. Skies it to the outfield.
+Result: Pop out to 2B (P4) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (88.2 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.1 mph), paints the corner. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (96.6 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.4 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Changeup (83.7 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.0 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Curveball (78.4 mph), low and away. Ball. Count: 1-1
+  Pitch: Curveball (80.7 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (91.5 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Slider (85.5 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Curveball (80.5 mph), right down the middle. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (90.1 mph), spikes before the plate. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.8 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.5 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (78.2 mph), high and tight. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.7 mph), drops onto the knees. Foul. Count: 1-1
+  Pitch: Curveball (80.4 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (91.1 mph), just misses outside. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (93.0 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Slider (85.6 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 2 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.7 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 2B: Jackson Riley, 1B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (84.6 mph), in the zone. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 3B: Caleb Jones, 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (79.9 mph), spikes before the plate. Foul. Count: 0-1
+  Pitch: Slider (86.1 mph), low and away. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), a bit inside. Swinging Strike. Count: 1-2
+  Pitch: Curveball (80.7 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 3B: Caleb Jones, 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (97.0 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (88.5 mph), drops onto the knees. Swinging Strike. Count: 1-1
+  Pitch: Slider (88.3 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Curveball (79.7 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.0 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Slider (89.7 mph), low and away. Ball. Count: 2-1
+  Pitch: Slider (87.6 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.7 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (80.7 mph), sails over the letters. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (95.9 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (89.4 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 2B: Hank Barrett, 1B: TJ Hawkins | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (95.4 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.6 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Curveball (78.1 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.6 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Changeup (81.7 mph), catches the black. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 3B: TJ Hawkins, 2B: Alex Chase | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.0 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Changeup (83.6 mph), low and away. Ball. Count: 2-0
+  Pitch: Slider (89.7 mph), snaps over the backdoor. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.6 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), catches the black. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (96.9 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (91.3 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.0 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (91.4 mph), snaps over the backdoor. Swinging Strike. Count: 2-1
+  Pitch: Two-Seam Fastball (91.9 mph), catches the black. Called Strike. Count: 2-2
+  Pitch: Two-Seam Fastball (90.0 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (78.8 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (79.9 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Curveball (79.3 mph), way outside. Ball. Count: 1-2
+  Pitch: Curveball (80.0 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Slider (84.6 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (79.2 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Slider (84.2 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (80.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.9 mph), a perfect strike. Called Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (90.6 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (89.3 mph), in the zone. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (88.6 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (82.4 mph), drops onto the knees. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 2 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (88.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Changeup (84.0 mph), way outside. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (94.3 mph), in the zone. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (78.3 mph), snaps over the backdoor. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (92.6 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (85.4 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (80.9 mph), a perfect strike. Swinging Strike. Count: 1-2
+  Pitch: Slider (84.4 mph), snaps over the backdoor. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Caleb Jones (SS, R)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Two-Seam Fastball (91.5 mph), spikes before the plate. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Changeup (83.6 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Changeup (82.6 mph), way outside. Foul. Count: 0-2
+  Pitch: Curveball (79.7 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.6 mph), a perfect strike. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.3 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (89.2 mph), a perfect strike. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.6 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Changeup (83.8 mph), right down the middle. Foul. Count: 2-2
+  Pitch: Slider (88.9 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Curveball (79.5 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.4 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Changeup (82.3 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Slider (88.6 mph), catches the black. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (91.5 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (84.5 mph), way outside. Ball. Count: 2-0
+  Pitch: Curveball (78.1 mph), a perfect strike. Foul. Count: 2-1
+  Pitch: Two-Seam Fastball (92.9 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Slider (85.5 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (91.4 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.5 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.2 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (92.4 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (93.7 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Curveball (81.3 mph), freezes him on the inner edge. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Nate Diaz, 1B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (95.6 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Curveball (81.3 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 3B: Nate Diaz, 1B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.0 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Curveball (79.0 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 3B: Nate Diaz, 1B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (93.7 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.1 mph), in the zone. Called Strike. Count: 0-2
+  Pitch: Knuckle-Curve (79.0 mph), low and away. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (77.4 mph), low and away. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (92.7 mph), sails over the letters. Ball. Count: 3-2
+  Pitch: Knuckle-Curve (78.0 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Knuckle-Curve (79.1 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (92.5 mph), drops onto the knees. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Knuckle-Curve (77.8 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.6 mph), catches the black. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Knuckle-Curve (78.0 mph), just misses outside. Rolls it over on the ground.
+Result: Dribbler in front, catcher fields (2-3) | Outs: 3 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (94.8 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (79.0 mph), just misses outside. Foul. Count: 0-2
+  Pitch: Curveball (81.1 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.7 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (95.3 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.0 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.2 mph), a perfect strike. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (93.2 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Curveball (79.2 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.5 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (94.8 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Knuckle-Curve (79.3 mph), a bit inside. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Knuckle-Curve (77.4 mph), low and away. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (79.5 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Knuckle-Curve (78.1 mph), high and tight. Ball. Count: 2-1
+  Pitch: Knuckle-Curve (78.4 mph), drops onto the knees. Called Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (94.4 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (93.5 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (77.4 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Knuckle-Curve (79.1 mph), drops onto the knees. Swinging Strike. Count: 2-1
+  Pitch: Knuckle-Curve (79.5 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Four-Seam Fastball (93.8 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (93.1 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.4 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Curveball (79.8 mph), a bit inside. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (94.3 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.0 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.6 mph), right down the middle. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (95.7 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.6 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (95.1 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (92.5 mph), way outside. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (77.1 mph), freezes him on the inner edge. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (93.8 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.3 mph), low and away. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (92.1 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (93.1 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (86.6 mph), catches the black. Called Strike. Count: 1-1
+  Pitch: Slider (87.6 mph), low and away. Ball. Count: 2-1
+  Pitch: Sinker (92.4 mph), paints the corner. Called Strike. Count: 2-2
+  Pitch: Sinker (92.7 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Sinker (91.6 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (87.1 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Sinker (92.2 mph), a bit inside. Ball. Count: 3-0
+  Pitch: Sinker (92.9 mph), a perfect strike. Called Strike. Count: 3-1
+  Pitch: Sinker (91.1 mph), right down the middle. Foul. Count: 3-2
+  Pitch: Sinker (93.1 mph), high and tight. Ball.
+Result: Walk         | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Quick throw to first and Evan Reed dives back safely.
+  Pitch: Slider (86.2 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Sinker (93.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Slider (86.4 mph), in the zone. Swinging Strike. Count: 1-2
+  Pitch: Slider (87.9 mph), a perfect strike. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (79.1 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Curveball (81.8 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.2 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Curveball (79.4 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Marcus Thorne (RF, L)
+  Quick throw to first and Grant Fisher dives back safely.
+  Pitch: Four-Seam Fastball (93.5 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.9 mph), way outside. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 2B: Grant Fisher, 1B: Marcus Thorne | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.9 mph), way outside. Ball. Count: 1-0
+  Pitch: Curveball (81.6 mph), drops onto the knees. Foul. Count: 1-1
+  Pitch: Curveball (81.0 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (93.4 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.9 mph), a bit inside. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (93.0 mph), spikes before the plate. Ball.
+Result: Walk         | Outs: 1 | Bases: 3B: Grant Fisher, 2B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (95.6 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.4 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Curveball (81.9 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (96.0 mph), a perfect strike. Called Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (94.0 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 3B: Grant Fisher, 2B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (95.4 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (80.0 mph), spikes before the plate. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (95.5 mph), snaps over the backdoor. Foul. Count: 2-1
+  Pitch: Four-Seam Fastball (93.4 mph), in the zone. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (93.7 mph), way outside. Skies it to the outfield.
+Result: Pop out to SS (P6) | Outs: 3 | Bases: 3B: Grant Fisher, 2B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 8
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 3 - Pacific City Pilots 8
+
+Pacific City Pilots win!

--- a/examples/game_05.txt
+++ b/examples/game_05.txt
@@ -1,0 +1,545 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 68°F, Overcast
+Umpires: HP: Frank Rizzo, 1B: Stan Friedman, 2B: Larry Phillips, 3B: Gus Morales
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.5 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Curveball (80.8 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (96.7 mph), low and away. Ball. Count: 1-2
+  Pitch: Slider (88.1 mph), low and away. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.7 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (89.3 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.9 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Slider (88.2 mph), drops onto the knees. Called Strike. Count: 1-2
+  Pitch: Slider (87.4 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Defensive alignment: Outfield shifts toward right-center.
+  Pitch: Four-Seam Fastball (95.5 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (96.5 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.7 mph), catches the black. Foul. Count: 1-1
+  Pitch: Slider (87.7 mph), snaps over the backdoor. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.2 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Changeup (83.2 mph), a bit inside. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (96.0 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.7 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Pop out to 1B (P3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (80.9 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Slider (85.4 mph), in the zone. Called Strike. Count: 0-2
+  Pitch: Slider (86.6 mph), snaps over the backdoor. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.5 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.2 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Slider (85.0 mph), drops onto the knees. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (92.9 mph), way outside. Ball. Count: 2-2
+  Pitch: Slider (86.3 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (79.6 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (88.3 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Slider (89.0 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.4 mph), catches the black. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (95.5 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (95.8 mph), a bit inside. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.1 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.9 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Slider (88.5 mph), catches the black. Foul. Count: 2-1
+  Pitch: Slider (89.7 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (94.9 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Changeup (82.6 mph), low and away. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 3B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (79.5 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.9 mph), catches the black. Foul. Count: 1-1
+  Pitch: Slider (85.8 mph), just misses outside. Ball. Count: 2-1
+  Pitch: Curveball (79.3 mph), high and tight. Lifts a routine fly ball.
+Result: Pop out to 3B (P5) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Two-Seam Fastball (92.1 mph), way outside. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (90.9 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Slider (86.7 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 1B: Owen Chen | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Miles Corbin (3B, S)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (86.0 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (92.5 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.5 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.7 mph), high and tight. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.3 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Slider (88.3 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (96.6 mph), way outside. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.3 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (91.0 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.4 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.1 mph), a perfect strike. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (92.5 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (80.8 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (79.5 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Curveball (78.4 mph), a perfect strike. Called Strike. Count: 1-2
+  Pitch: Curveball (79.2 mph), drops onto the knees. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (90.4 mph), catches the black. Foul. Count: 0-1
+  Pitch: Curveball (80.8 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.4 mph), high and tight. Ball. Count: 2-1
+  Pitch: Curveball (80.9 mph), in the zone. Foul. Count: 2-2
+  Pitch: Curveball (79.3 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (92.2 mph), in the zone. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (94.7 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Curveball (78.4 mph), paints the corner. Called Strike. Count: 1-1
+  Pitch: Changeup (83.6 mph), catches the black. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.1 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (89.6 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (95.9 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Changeup (83.4 mph), catches the black. Foul. Count: 0-2
+  Pitch: Changeup (83.9 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.0 mph), spikes before the plate. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (91.7 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.2 mph), in the zone. Swinging Strike. Count: 1-2
+  Pitch: Slider (84.8 mph), in the zone. Skies it to the outfield.
+Result: Pop out to 2B (P4) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.7 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (80.6 mph), high and tight. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.3 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (79.6 mph), paints the corner. Chops a bouncer toward the infield.
+  Ground ball to second... 4-6-3 double play!
+Result: Groundout, Double Play (GDP (4-6-3)) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (96.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Curveball (79.0 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.8 mph), just misses outside. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (97.0 mph), in the zone. Foul. Count: 1-2
+  Pitch: Changeup (83.0 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+Now batting: TJ Hawkins (RF, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Four-Seam Fastball (96.4 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Two-Seam Fastball (92.0 mph), paints the corner. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (90.2 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.0 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.6 mph), catches the black. Lifts a routine fly ball.
+Result: Pop out to 2B (P4) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.7 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.1 mph), high and tight. Ball. Count: 2-0
+  Pitch: Curveball (78.0 mph), paints the corner. Foul. Count: 2-1
+  Pitch: Two-Seam Fastball (91.6 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Two-Seam Fastball (91.1 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.0 mph), high and tight. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (92.8 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (80.9 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Changeup (82.7 mph), way outside. Ball. Count: 2-0
+  Pitch: Slider (87.7 mph), right down the middle. Swinging Strike. Count: 2-1
+  Pitch: Four-Seam Fastball (96.9 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Changeup (82.0 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (96.9 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Changeup (81.4 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Slider (88.7 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Slider (87.7 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (88.5 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.4 mph), snaps over the backdoor. Called Strike. Count: 1-1
+  Pitch: Curveball (78.2 mph), paints the corner. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (95.6 mph), high and tight. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (91.1 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (80.3 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Curveball (78.3 mph), right down the middle. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.2 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.4 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.7 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Changeup (82.5 mph), a bit inside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.8 mph), a bit inside. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Felix Washington | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.5 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Slider (89.2 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (94.3 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (92.0 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.9 mph), a perfect strike. Called Strike. Count: 1-1
+  Pitch: Slider (86.1 mph), a perfect strike. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.6 mph), just misses outside. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (91.0 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.9 mph), spikes before the plate. Ball. Count: 1-2
+  Pitch: Slider (86.5 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (91.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.7 mph), way outside. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (90.8 mph), way outside. Ball. Count: 2-1
+  Pitch: Curveball (80.8 mph), low and away. Ball. Count: 3-1
+  Pitch: Slider (86.6 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 2 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (94.2 mph), catches the black. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (96.0 mph), freezes him on the inner edge. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: TJ Hawkins | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (78.1 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.0 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 3B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 2, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (95.6 mph), in the dirt. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 3B: Alex Chase, 2B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (89.2 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Changeup (83.1 mph), low and away. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (97.0 mph), right down the middle. Foul. Count: 2-1
+  Pitch: Slider (87.5 mph), a bit inside. Ball. Count: 3-1
+  Pitch: Curveball (79.4 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 3B: Kevin Webb | Score: Bay Area Bombers: 2, Pacific City Pilots: 2
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Knuckle-Curve (79.6 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.7 mph), snaps over the backdoor. Called Strike. Count: 0-2
+  Pitch: Knuckle-Curve (79.6 mph), a perfect strike. Lifts a routine fly ball.
+  Sacrifice fly to LF, Kevin Webb scores!
+Result: Flyout to LF (F7 (SF)) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (94.6 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.5 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Knuckle-Curve (79.4 mph), way outside. Ball. Count: 3-0
+  Pitch: Four-Seam Fastball (93.1 mph), in the zone. Called Strike. Count: 3-1
+  Pitch: Four-Seam Fastball (94.7 mph), just misses outside. Ball.
+Result: Walk         | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Knuckle-Curve (77.5 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.1 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Knuckle-Curve (79.0 mph), catches the black. Swinging Strike. Count: 2-1
+  Pitch: Knuckle-Curve (79.4 mph), spikes before the plate. Ball. Count: 3-1
+  Pitch: Knuckle-Curve (79.0 mph), a perfect strike. Swinging Strike. Count: 3-2
+  Pitch: Four-Seam Fastball (93.4 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (79.4 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (81.4 mph), in the zone. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (93.3 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 3B: Leo Vance | Score: Bay Area Bombers: 2, Pacific City Pilots: 3
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.2 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.5 mph), right down the middle. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.4 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (79.3 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (93.8 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (77.4 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Knuckle-Curve (77.5 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (92.3 mph), low and away. Ball. Count: 2-2
+  Pitch: Knuckle-Curve (78.9 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Wes Griffin (SS, S)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Knuckle-Curve (79.2 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (77.1 mph), a perfect strike. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.0 mph), way outside. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (79.5 mph), in the zone. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: TJ Hawkins (RF, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (93.5 mph), low and away. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (77.0 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.1 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Sinker (92.3 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (86.9 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 2B: Wes Griffin, 1B: Alex Chase | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (86.0 mph), just misses outside. Swinging Strike. Count: 0-1
+  Pitch: Sinker (92.9 mph), snaps over the backdoor. Swinging Strike. Count: 0-2
+  Pitch: Slider (87.6 mph), in the zone. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 2B: Wes Griffin, 1B: Alex Chase | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (80.2 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Curveball (81.2 mph), right down the middle. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.5 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (79.4 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Curveball (80.6 mph), a bit inside. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 3B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (93.8 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.8 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to 2B (P4) | Outs: 2 | Bases: 3B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (79.7 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Curveball (81.4 mph), in the zone. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.3 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Curveball (81.4 mph), in the zone. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 3B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Automatic runner on second: Kevin Webb jogs out to take his lead.
+--------------------------------------------------
+Top of Inning 10 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Sinker (93.6 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Slider (87.8 mph), way outside. Ball. Count: 2-0
+  Pitch: Sinker (93.5 mph), low and away. Foul. Count: 2-1
+  Pitch: Slider (87.2 mph), a bit inside. Ball. Count: 3-1
+  Pitch: Slider (87.5 mph), a perfect strike. Foul. Count: 3-2
+  Pitch: Sinker (92.7 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 3, Pacific City Pilots: 3
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (92.1 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Sinker (91.3 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Sinker (92.0 mph), a perfect strike. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Sinker (93.1 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Sinker (91.9 mph), high and tight. Ball. Count: 2-0
+  Pitch: Sinker (92.3 mph), freezes him on the inner edge. Foul. Count: 2-1
+  Pitch: Slider (86.6 mph), catches the black. Swinging Strike. Count: 2-2
+  Pitch: Sinker (93.3 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (92.9 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Sinker (92.1 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Slider (86.8 mph), spikes before the plate. Foul. Count: 1-1
+  Pitch: Sinker (92.2 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Automatic runner on second: Miles Corbin jogs out to take his lead.
+--------------------------------------------------
+Bottom of Inning 10 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (93.1 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Curveball (79.3 mph), in the zone. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.3 mph), high and tight. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.5 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (95.9 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.7 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.7 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Curveball (81.4 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 3B: Miles Corbin | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (79.9 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.7 mph), a perfect strike. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.6 mph), a perfect strike. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 3B: Miles Corbin | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 3 - Pacific City Pilots 5
+
+Pacific City Pilots win!

--- a/examples/game_06.txt
+++ b/examples/game_06.txt
@@ -1,0 +1,556 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 55°F, Drizzle
+Umpires: HP: Gus Morales, 1B: Frank Rizzo, 2B: Chuck Thompson, 3B: Larry Phillips
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.6 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (78.2 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Slider (88.0 mph), in the dirt. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.0 mph), snaps over the backdoor. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.1 mph), way outside. Ball. Count: 1-0
+  Pitch: Curveball (79.5 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (94.2 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Changeup (83.4 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.3 mph), snaps over the backdoor. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (97.0 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.3 mph), sails over the letters. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.2 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.5 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (91.2 mph), spikes before the plate. Foul. Count: 2-1
+  Pitch: Curveball (80.1 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Curveball (79.6 mph), a bit inside. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (91.4 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 2B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (90.3 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.5 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.2 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: 2B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (85.6 mph), just misses outside. Swinging Strike. Count: 0-1
+  Pitch: Curveball (79.4 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (90.8 mph), snaps over the backdoor. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Slider (85.6 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.0 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Curveball (79.5 mph), way outside. Ball. Count: 2-1
+  Pitch: Slider (86.0 mph), right down the middle. Foul. Count: 2-2
+  Pitch: Curveball (78.2 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.2 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.0 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Curveball (79.5 mph), a bit inside. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (90.2 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (94.6 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.6 mph), paints the corner. Rolls it over on the ground.
+  An error by SS Caleb Jones allows the batter to reach base.
+Result: Reached on Error (E6) | Outs: 0 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Defensive alignment: Outfield shifts toward right-center.
+  Pitch: Slider (89.8 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Changeup (81.9 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.8 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Changeup (82.0 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 3B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 0
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (95.9 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.7 mph), a perfect strike. Called Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.9 mph), a perfect strike. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (89.9 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Slider (88.8 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Curveball (80.2 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Changeup (81.1 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (91.7 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (85.0 mph), high and tight. Ball. Count: 1-0
+  Pitch: Curveball (80.3 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Slider (84.5 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Curveball (79.5 mph), snaps over the backdoor. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (90.1 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.0 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.4 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (80.7 mph), right down the middle. Lifts a routine fly ball.
+Result: Pop out to 1B (P3) | Outs: 2 | Bases: 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.9 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.8 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Curveball (80.2 mph), catches the black. Swinging Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (91.8 mph), spikes before the plate. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (83.8 mph), a bit inside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.2 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Changeup (83.9 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.6 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Slider (88.8 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Curveball (80.7 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.7 mph), paints the corner. Lifts a routine fly ball.
+  An error by 1B Owen Chen allows the batter to reach base.
+Result: Reached on Error (E3) | Outs: 2 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.9 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.0 mph), high and tight. Foul. Count: 0-2
+  Pitch: Curveball (80.6 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.3 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.6 mph), way outside. Ball. Count: 2-0
+  Pitch: Slider (86.0 mph), just misses outside. Ball. Count: 3-0
+  Pitch: Two-Seam Fastball (90.6 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (79.0 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Curveball (78.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (92.1 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (92.1 mph), snaps over the backdoor. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.9 mph), in the dirt. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.3 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Slider (85.0 mph), freezes him on the inner edge. Swinging Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (92.6 mph), a perfect strike. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (85.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.8 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Sam Decker, 1B: Nate Diaz | Score: Bay Area Bombers: 3, Pacific City Pilots: 2
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (84.1 mph), sails over the letters. Lifts a routine fly ball.
+  An error by LF Evan Reed allows the batter to reach base.
+Result: Reached on Error (E7) | Outs: 2 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (78.6 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (87.7 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Slider (87.1 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Curveball (79.5 mph), paints the corner. Hooks a double down the line!
+Result: Double       | Outs: 1 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.4 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.2 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Changeup (83.6 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.3 mph), sails over the letters. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.8 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Slider (89.5 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.7 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 3B: Hank Barrett, 1B: TJ Hawkins | Score: Bay Area Bombers: 4, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.2 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.2 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.3 mph), catches the black. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (81.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Slider (88.4 mph), low and away. Ball. Count: 1-1
+  Pitch: Slider (88.9 mph), a perfect strike. Called Strike. Count: 1-2
+  Pitch: Slider (88.1 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (78.6 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.1 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Curveball (79.1 mph), in the dirt. Swinging Strike. Count: 1-2
+  Pitch: Curveball (79.0 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (91.3 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (80.4 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (80.4 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (80.5 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.0 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Curveball (78.0 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.6 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.9 mph), freezes him on the inner edge. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 4, Pacific City Pilots: 5
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.1 mph), in the zone. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: Rex Power | Score: Bay Area Bombers: 4, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.7 mph), high and tight. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Changeup (83.4 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Slider (87.6 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (88.5 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Slider (88.7 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Slider (89.1 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.3 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Changeup (83.9 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 0 | Bases: 2B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.4 mph), way outside. Ball. Count: 1-0
+  Pitch: Changeup (82.3 mph), way outside. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (96.2 mph), a perfect strike. Called Strike. Count: 2-1
+  Pitch: Four-Seam Fastball (94.1 mph), way outside. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.0 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Pop out to 2B (P4) | Outs: 2 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Curveball (80.6 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (80.7 mph), spikes before the plate. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (78.1 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (93.0 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.7 mph), low and away. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (94.0 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (82.0 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Curveball (80.5 mph), catches the black. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (95.8 mph), freezes him on the inner edge. Swinging Strike. Count: 1-2
+  Pitch: Slider (87.6 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Knuckle-Curve (79.6 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.2 mph), spikes before the plate. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (86.7 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.8 mph), in the zone. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (92.7 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Slider (85.5 mph), catches the black. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (90.8 mph), catches the black. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Slider (86.1 mph), just misses outside. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 1B: Miles Corbin | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (93.3 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 7
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Knuckle-Curve (79.0 mph), snaps over the backdoor. Called Strike. Count: 0-1
+  Pitch: Knuckle-Curve (79.9 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (94.4 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Called Strike. Count: 0-2
+  Pitch: Knuckle-Curve (78.8 mph), way outside. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (78.5 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (92.7 mph), low and away. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Leo Vance (CF, L)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Four-Seam Fastball (93.1 mph), high and tight. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (93.7 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Curveball (80.3 mph), drops onto the knees. Called Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (93.2 mph), high and tight. Ball. Count: 2-1
+  Pitch: Curveball (79.9 mph), in the zone. Called Strike. Count: 2-2
+  Pitch: Curveball (80.8 mph), drops onto the knees. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 2B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Passed Ball! Runners advance.
+  Pitch: Curveball (81.5 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.2 mph), high and tight. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (93.4 mph), drops onto the knees. Foul. Count: 2-1
+  Pitch: Four-Seam Fastball (94.4 mph), paints the corner. Called Strike. Count: 2-2
+  Pitch: Curveball (80.5 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (94.2 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 3B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (95.3 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.4 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Curveball (79.8 mph), drops onto the knees. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 3B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Knuckle-Curve (77.2 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (92.9 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.5 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Knuckle-Curve (78.4 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (92.1 mph), high and tight. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (79.0 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (94.6 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.4 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (95.1 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), freezes him on the inner edge. Called Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (94.2 mph), low and away. Ball. Count: 2-1
+  Pitch: Curveball (80.9 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (95.3 mph), low and away. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (94.0 mph), in the zone. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (80.9 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Curveball (81.4 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Curveball (79.1 mph), high and tight. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.2 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Owen Chen | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (94.2 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Curveball (79.9 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.7 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Grant Fisher (LF, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (94.5 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.9 mph), freezes him on the inner edge. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.6 mph), catches the black. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (93.8 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.7 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (93.0 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.2 mph), paints the corner. Swinging Strike. Count: 0-2
+  Pitch: Knuckle-Curve (77.9 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (92.8 mph), high and tight. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (79.2 mph), freezes him on the inner edge. Swinging Strike. Count: 0-2
+  Pitch: Knuckle-Curve (78.4 mph), catches the black. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (94.2 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Marcus Thorne (RF, L)
+  Passed Ball! Runners advance.
+  Pitch: Four-Seam Fastball (93.1 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 3B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (95.9 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (95.9 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.8 mph), in the zone. Lifts a routine fly ball.
+Result: Pop out to 2B (P4) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (95.5 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.8 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.2 mph), right down the middle. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (95.1 mph), in the zone. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.5 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.2 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.6 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Quick throw to first and Nate Diaz dives back safely.
+  Pitch: Four-Seam Fastball (94.3 mph), high and tight. Ball. Count: 1-0
+  Pitch: Curveball (80.3 mph), sails over the letters. Ball. Count: 2-0
+  Pitch: Curveball (81.6 mph), in the zone. Foul. Count: 2-1
+  Pitch: Curveball (79.0 mph), paints the corner. Swinging Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (95.6 mph), catches the black. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+
+--- Pitching Change for Pacific City Pilots: Rollie Malone replaces Ben Logan ---
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Sinker (91.9 mph), catches the black. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Nate Diaz, 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Sinker (92.2 mph), way outside. Ball. Count: 1-0
+  Pitch: Sinker (91.1 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Slider (85.9 mph), low and away. Foul. Count: 1-2
+  Pitch: Sinker (90.5 mph), low and away. Ball. Count: 2-2
+  Pitch: Sinker (91.6 mph), a bit inside. Ball. Count: 3-2
+  Pitch: Sinker (91.8 mph), sails over the letters. Ball.
+Result: Walk         | Outs: 2 | Bases: 3B: Owen Chen, 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Sinker (92.3 mph), right down the middle. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 3B: Miles Corbin, 2B: Grant Fisher, 1B: Leo Vance | Score: Bay Area Bombers: 9, Pacific City Pilots: 8
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 9 - Pacific City Pilots 8
+
+Bay Area Bombers win!

--- a/examples/game_07.txt
+++ b/examples/game_07.txt
@@ -1,0 +1,575 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 72°F, Partly Cloudy, Wind 10 mph L to R
+Umpires: HP: Stan Friedman, 1B: Gus Morales, 2B: Frank Rizzo, 3B: Chuck Thompson
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (78.3 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Curveball (79.1 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.5 mph), catches the black. Foul. Count: 0-2
+  Pitch: Slider (87.0 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.8 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Slider (86.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.0 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Slider (85.0 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (80.3 mph), paints the corner. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (80.0 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Quick throw to first and Marcus Thorne dives back safely.
+  Pitch: Two-Seam Fastball (90.6 mph), low and away. Ball. Count: 1-0
+  Pitch: Curveball (79.3 mph), way outside. Ball. Count: 2-0
+  Pitch: Curveball (78.7 mph), in the dirt. Ball. Count: 3-0
+  Pitch: Curveball (80.1 mph), paints the corner. Swinging Strike. Count: 3-1
+  Pitch: Two-Seam Fastball (91.4 mph), catches the black. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Curveball (79.3 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.2 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.4 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Changeup (81.3 mph), freezes him on the inner edge. Swinging Strike. Count: 2-2
+  Pitch: Changeup (82.3 mph), sails over the letters. Ball. Count: 3-2
+  Pitch: Slider (87.6 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Changeup (81.5 mph), right down the middle. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (96.4 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.7 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.3 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Slider (87.9 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Slider (84.6 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.4 mph), right down the middle. Swinging Strike. Count: 0-2
+  Pitch: Curveball (79.2 mph), spikes before the plate. Ball. Count: 1-2
+  Pitch: Curveball (80.3 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Curveball (80.3 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (86.7 mph), way outside. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (92.5 mph), low and away. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (91.6 mph), a bit inside. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (90.2 mph), spikes before the plate. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (90.1 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (91.8 mph), high and tight. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.2 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (92.5 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (92.7 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (95.7 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Slider (87.9 mph), spikes before the plate. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.9 mph), way outside. Ball. Count: 1-2
+  Pitch: Slider (87.7 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Changeup (82.5 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.7 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (88.1 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Slider (88.5 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.1 mph), right down the middle. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: Wes Griffin, 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (82.3 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Slider (88.5 mph), low and away. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.5 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Slider (88.9 mph), low and away. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.8 mph), way outside. Ball. Count: 3-2
+  Pitch: Slider (89.2 mph), freezes him on the inner edge. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Wes Griffin, 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (96.1 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Alex Chase, 2B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Curveball (81.0 mph), paints the corner. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.5 mph), in the zone. Foul. Count: 0-1
+  Pitch: Slider (87.3 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Miles Corbin (3B, S)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Two-Seam Fastball (93.0 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (85.2 mph), way outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (90.1 mph), right down the middle. Swinging Strike. Count: 2-1
+  Pitch: Two-Seam Fastball (92.8 mph), right down the middle. Swinging Strike. Count: 2-2
+  Pitch: Two-Seam Fastball (91.8 mph), a perfect strike. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (80.7 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (92.7 mph), high and tight. Ball. Count: 1-1
+  Pitch: Curveball (78.2 mph), a perfect strike. Swinging Strike. Count: 1-2
+  Pitch: Slider (86.4 mph), just misses outside. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (91.4 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (90.0 mph), spikes before the plate. Ball.
+Result: Walk         | Outs: 1 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.9 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Curveball (78.8 mph), in the zone. Foul. Count: 1-1
+  Pitch: Curveball (80.9 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (91.7 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (87.0 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (89.1 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (96.7 mph), catches the black. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.0 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Changeup (81.6 mph), catches the black. Foul. Count: 0-1
+  Pitch: Slider (87.3 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 3B: Hank Barrett, 2B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 4
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (96.9 mph), catches the black. Foul. Count: 0-1
+  Pitch: Slider (89.7 mph), freezes him on the inner edge. Skies it to the outfield.
+  Sacrifice fly to CF, Hank Barrett scores!
+Result: Flyout to CF (F8 (SF)) | Outs: 2 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 5
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Changeup (82.8 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Curveball (81.0 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Curveball (79.8 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 2B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.6 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 2B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (91.4 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.8 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Slider (84.3 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Slider (84.5 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Two-Seam Fastball (92.1 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (85.2 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.7 mph), freezes him on the inner edge. Foul. Count: 1-1
+  Pitch: Slider (85.5 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (90.4 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Curveball (80.5 mph), low and away. Ball. Count: 3-2
+  Pitch: Two-Seam Fastball (91.6 mph), a bit inside. Ball.
+Result: Walk         | Outs: 1 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Slider (86.9 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.1 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (90.8 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (91.7 mph), low and away. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (90.4 mph), drops onto the knees. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (93.0 mph), drops onto the knees. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 3B: Jackson Riley, 2B: Nate Diaz | Score: Bay Area Bombers: 0, Pacific City Pilots: 6
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (85.4 mph), catches the black. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (90.1 mph), high and tight. Ball. Count: 1-1
+  Pitch: Curveball (80.0 mph), right down the middle. Swinging Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (90.4 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Miles Corbin (3B, S)
+  Defensive alignment: Outfield shifts toward right-center.
+  Pitch: Slider (84.8 mph), low and away. Ball. Count: 1-0
+  Pitch: Curveball (78.7 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Changeup (82.4 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.5 mph), spikes before the plate. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (96.8 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.2 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (87.9 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.3 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Slider (88.2 mph), in the zone. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (97.0 mph), high and tight. Ball. Count: 2-2
+  Pitch: Slider (89.1 mph), a perfect strike. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (78.4 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.8 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Slider (84.6 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Slider (84.6 mph), just misses outside. Ball. Count: 2-2
+  Pitch: Curveball (79.7 mph), way outside. Ball. Count: 3-2
+  Pitch: Curveball (79.9 mph), freezes him on the inner edge. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (93.7 mph), high and tight. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.9 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (96.0 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (95.0 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.0 mph), high and tight. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (93.4 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (93.2 mph), drops onto the knees. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (93.3 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (95.9 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (89.8 mph), catches the black. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.6 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Curveball (78.6 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.5 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Changeup (83.6 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (94.8 mph), drops onto the knees. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 2B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 7
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.8 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Slider (87.9 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Curveball (79.3 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Changeup (82.4 mph), in the zone. Foul. Count: 2-2
+  Pitch: Slider (88.9 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (96.2 mph), a bit inside. Ball.
+Result: Walk         | Outs: 2 | Bases: 2B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 3, Pacific City Pilots: 7
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.5 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Slider (88.7 mph), right down the middle. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Four-Seam Fastball (95.6 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.6 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Slider (89.9 mph), freezes him on the inner edge. Swinging Strike. Count: 1-2
+  Pitch: Slider (89.3 mph), high and tight. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (82.0 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), way outside. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (94.4 mph), snaps over the backdoor. Foul. Count: 2-1
+  Pitch: Four-Seam Fastball (93.1 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (94.7 mph), freezes him on the inner edge. Rolls it over on the ground.
+  An error by SS Wes Griffin allows the batter to reach base.
+Result: Reached on Error (E6) | Outs: 1 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (93.3 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (95.3 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (79.8 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.1 mph), snaps over the backdoor. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.1 mph), catches the black. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (89.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Slider (89.4 mph), sails over the letters. Ball. Count: 2-0
+  Pitch: Changeup (81.9 mph), sails over the letters. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (92.6 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.7 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.3 mph), in the zone. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (94.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (92.5 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (92.7 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.6 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (93.7 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 2B: Rex Power, 1B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 10
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Four-Seam Fastball (93.1 mph), in the zone. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (93.1 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Curveball (79.7 mph), paints the corner. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.9 mph), drops onto the knees. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (93.6 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (95.4 mph), drops onto the knees. Skies it to the outfield.
+Result: Pop out to SS (P6) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (81.9 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (79.8 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.1 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.0 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (94.3 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Curveball (80.9 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.6 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (92.4 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to SS (P6) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (93.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (92.6 mph), way outside. Ball. Count: 2-0
+  Pitch: Knuckle-Curve (77.5 mph), a bit inside. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Knuckle-Curve (79.7 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (93.1 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (92.9 mph), catches the black. Called Strike. Count: 1-1
+  Pitch: Knuckle-Curve (77.7 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (92.9 mph), way outside. Ball. Count: 2-2
+  Pitch: Knuckle-Curve (77.9 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Knuckle-Curve (77.7 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (94.1 mph), right down the middle. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (81.4 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.3 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.1 mph), freezes him on the inner edge. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (95.9 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.3 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.0 mph), a perfect strike. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (93.1 mph), catches the black. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (81.6 mph), low and away. Foul. Count: 0-1
+  Pitch: Curveball (80.3 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (92.9 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (77.3 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Knuckle-Curve (79.6 mph), spikes before the plate. Ball. Count: 1-2
+  Pitch: Knuckle-Curve (77.5 mph), catches the black. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 10
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (93.1 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.9 mph), just misses outside. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (92.6 mph), freezes him on the inner edge. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Slider (86.8 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Slider (87.1 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Slider (87.7 mph), in the dirt. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (87.7 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Sinker (93.6 mph), in the zone. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (86.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Sinker (92.8 mph), in the zone. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 2B: Hank Barrett, 1B: TJ Hawkins | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Alex Chase (2B, R)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Slider (87.4 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Slider (86.3 mph), a bit inside. Ball. Count: 2-0
+  Pitch: Sinker (93.6 mph), paints the corner. Called Strike. Count: 2-1
+  Pitch: Sinker (91.9 mph), in the dirt. Foul. Count: 2-2
+  Pitch: Sinker (92.1 mph), a bit inside. Ball. Count: 3-2
+  Pitch: Sinker (92.4 mph), a perfect strike. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 3 | Bases: 2B: Hank Barrett, 1B: TJ Hawkins | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (94.3 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.1 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (93.7 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (79.9 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.5 mph), snaps over the backdoor. Called Strike. Count: 0-2
+  Pitch: Curveball (79.1 mph), in the dirt. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (93.5 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (95.7 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.6 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.1 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+
+--- Pitching Change for Pacific City Pilots: Rollie Malone replaces Ben Logan ---
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Sinker (92.7 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (87.6 mph), a bit inside. Ball. Count: 2-0
+  Pitch: Sinker (91.3 mph), in the zone. Swinging Strike. Count: 2-1
+  Pitch: Sinker (92.9 mph), just misses outside. Ball. Count: 3-1
+  Pitch: Sinker (91.9 mph), in the zone. Called Strike. Count: 3-2
+  Pitch: Slider (85.5 mph), high and tight. Ball.
+Result: Walk         | Outs: 2 | Bases: 2B: Grant Fisher, 1B: Leo Vance | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Sinker (92.4 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Slider (85.1 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Sinker (92.1 mph), high and tight. Ball. Count: 2-1
+  Pitch: Sinker (90.2 mph), in the zone. Foul. Count: 2-2
+  Pitch: Sinker (91.4 mph), sails over the letters. Ball. Count: 3-2
+  Pitch: Sinker (91.4 mph), way outside. Ball.
+Result: Walk         | Outs: 2 | Bases: 3B: Grant Fisher, 2B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.0 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 3B: Grant Fisher, 2B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 4, Pacific City Pilots: 11
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 4 - Pacific City Pilots 11
+
+Pacific City Pilots win!

--- a/examples/game_08.txt
+++ b/examples/game_08.txt
@@ -1,0 +1,526 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 68°F, Overcast
+Umpires: HP: Frank Rizzo, 1B: Larry Phillips, 2B: Gus Morales, 3B: Chuck Thompson
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Slider (87.5 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (95.7 mph), a perfect strike. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 1 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Changeup (83.7 mph), high and tight. Foul. Count: 0-1
+  Pitch: Changeup (82.6 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Changeup (83.5 mph), drops onto the knees. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 3B: Alex Chase, 2B: Omar Ramirez | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (89.5 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.9 mph), paints the corner. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.6 mph), in the zone. Foul. Count: 1-2
+  Pitch: Slider (88.7 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.7 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 3B: Alex Chase, 2B: Omar Ramirez | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.6 mph), catches the black. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Omar Ramirez, 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Quick throw to first and Evan Reed dives back safely.
+  Pitch: Curveball (79.4 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Slider (88.9 mph), snaps over the backdoor. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (94.1 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.1 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (95.1 mph), snaps over the backdoor. Skies it to the outfield.
+  An error by LF Grant Fisher allows the batter to reach base.
+Result: Reached on Error (E7) | Outs: 2 | Bases: 3B: Felix Washington, 1B: Hank Barrett | Score: Bay Area Bombers: 0, Pacific City Pilots: 3
+
+Now batting: Wes Griffin (SS, S)
+  Quick throw to first and Hank Barrett dives back safely.
+  Pitch: Slider (89.1 mph), in the zone. Drives it into the corner for a stand-up triple!
+Result: Triple       | Outs: 2 | Bases: 3B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 5
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (96.0 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.9 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 3 | Bases: 3B: Wes Griffin | Score: Bay Area Bombers: 0, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.7 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.2 mph), a perfect strike. Laces a ringing double off the wall!
+Result: Double       | Outs: 0 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (78.3 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 3B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 5
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (91.0 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Curveball (79.5 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (86.9 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Curveball (79.9 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.9 mph), in the zone. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.1 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (90.9 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.0 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (96.5 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Slider (88.8 mph), catches the black. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Slider (89.8 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.7 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Curveball (79.2 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (95.9 mph), paints the corner. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (91.0 mph), low and away. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (80.8 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Curveball (79.8 mph), a bit inside. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.6 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (84.4 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (91.2 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), a perfect strike. Called Strike. Count: 1-2
+  Pitch: Two-Seam Fastball (92.6 mph), in the dirt. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (91.1 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.1 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.6 mph), way outside. Ball. Count: 2-1
+  Wild Pitch! Runners advance.
+  Pitch: Two-Seam Fastball (90.8 mph), way outside. Ball. Count: 3-1
+  Pitch: Slider (84.2 mph), in the zone. Swinging Strike. Count: 3-2
+  Pitch: Two-Seam Fastball (90.5 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 3B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (81.3 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.5 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Slider (87.9 mph), a perfect strike. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (87.7 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (94.9 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.3 mph), right down the middle. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Changeup (82.7 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Slider (87.0 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.2 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 3 | Bases: 2B: Felix Washington | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (80.9 mph), catches the black. Foul. Count: 0-1
+  Pitch: Curveball (80.8 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Curveball (78.2 mph), low and away. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (91.6 mph), low and away. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (86.4 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Slider (86.9 mph), way outside. Ball. Count: 2-0
+  Pitch: Curveball (79.5 mph), a perfect strike. Foul. Count: 2-1
+  Pitch: Slider (86.6 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Slider (85.6 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Sam Decker (C, R)
+  Pitch: Curveball (80.6 mph), high and tight. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.7 mph), in the zone. Foul. Count: 1-1
+  Pitch: Two-Seam Fastball (92.5 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Curveball (79.5 mph), low and away. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (91.9 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (96.7 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.7 mph), high and tight. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (89.9 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (89.2 mph), paints the corner. Foul. Count: 1-1
+  Pitch: Curveball (79.5 mph), high and tight. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (96.2 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Slider (88.7 mph), just misses outside. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (97.0 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (87.7 mph), paints the corner. Called Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (96.9 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Curveball (78.9 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 2B: Wes Griffin | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (83.3 mph), catches the black. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.7 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Changeup (83.5 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Wes Griffin, 1B: Kevin Webb | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.2 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Changeup (81.7 mph), low and away. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 3B: Wes Griffin, 1B: Kevin Webb | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (90.0 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (80.5 mph), just misses outside. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.6 mph), freezes him on the inner edge. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (90.7 mph), catches the black. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 2B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (80.4 mph), way outside. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Caleb Jones, 1B: Nate Diaz | Score: Bay Area Bombers: 1, Pacific City Pilots: 5
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.3 mph), sails over the letters. Laces a ringing double off the wall!
+Result: Double       | Outs: 1 | Bases: 3B: Nate Diaz, 2B: Owen Chen | Score: Bay Area Bombers: 2, Pacific City Pilots: 5
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Two-Seam Fastball (90.5 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Slider (85.6 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Curveball (79.1 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Curveball (80.9 mph), low and away. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (91.5 mph), freezes him on the inner edge. Foul. Count: 3-2
+  Pitch: Curveball (79.1 mph), snaps over the backdoor. Skies it to the outfield.
+  Sacrifice fly to CF, Nate Diaz scores!
+Result: Flyout to CF (F8 (SF)) | Outs: 2 | Bases: 2B: Owen Chen | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (92.3 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 2B: Owen Chen | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (82.8 mph), high and tight. Ball. Count: 1-0
+  Pitch: Changeup (82.8 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.3 mph), sails over the letters. Lifts a routine fly ball.
+Result: Pop out to 3B (P5) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Curveball (78.6 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.5 mph), snaps over the backdoor. Swinging Strike. Count: 1-1
+  Pitch: Slider (87.3 mph), paints the corner. Swinging Strike. Count: 1-2
+  Pitch: Curveball (80.4 mph), drops onto the knees. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (80.1 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Curveball (78.4 mph), way outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (92.4 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (85.2 mph), spikes before the plate. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.9 mph), in the dirt. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: Marcus Thorne | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.7 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.5 mph), way outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (90.2 mph), right down the middle. Called Strike. Count: 2-1
+  Pitch: Two-Seam Fastball (90.4 mph), high and tight. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (90.8 mph), a perfect strike. Called Strike. Count: 3-2
+  Pitch: Two-Seam Fastball (93.0 mph), just misses outside. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 2B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (86.7 mph), catches the black. Foul. Count: 0-1
+  Pitch: Curveball (79.7 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (92.1 mph), snaps over the backdoor. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 2B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (79.7 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 3B: Marcus Thorne, 2B: Sam Decker, 1B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (80.1 mph), low and away. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 3B: Marcus Thorne, 2B: Sam Decker, 1B: Caleb Jones | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (95.0 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Slider (88.2 mph), drops onto the knees. Swinging Strike. Count: 1-1
+  Pitch: Curveball (78.6 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.9 mph), right down the middle. Chops a bouncer toward the infield.
+  An error by 1B Owen Chen allows the batter to reach base.
+Result: Reached on Error (E3) | Outs: 0 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (89.2 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (89.4 mph), just misses outside. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 3, Pacific City Pilots: 5
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (88.4 mph), sails over the letters. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.2 mph), catches the black. Foul. Count: 0-2
+  Pitch: Curveball (80.1 mph), in the zone. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 2B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Changeup (81.2 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.4 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (96.9 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 3B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Foul. Count: 0-1
+  Pitch: Slider (89.7 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Slider (89.3 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 3B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (90.8 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.6 mph), catches the black. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (92.2 mph), low and away. Ball. Count: 1-2
+  Pitch: Slider (84.5 mph), freezes him on the inner edge. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (93.1 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (93.4 mph), in the zone. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.4 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (79.1 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.1 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Joe Gibson ---
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (86.9 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (86.8 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Sinker (93.9 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Sinker (91.8 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (91.1 mph), sails over the letters. Foul. Count: 0-1
+  Pitch: Sinker (93.7 mph), catches the black. Foul. Count: 0-2
+  Pitch: Sinker (92.4 mph), way outside. Ball. Count: 1-2
+  Pitch: Sinker (91.0 mph), way outside. Ball. Count: 2-2
+  Pitch: Sinker (93.7 mph), in the dirt. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.0 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (91.9 mph), a bit inside. Swinging Strike. Count: 0-1
+  Pitch: Sinker (93.1 mph), paints the corner. Swinging Strike. Count: 0-2
+  Pitch: Sinker (91.8 mph), snaps over the backdoor. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 3B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Sinker (92.5 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Sinker (91.1 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 3B: Evan Reed, 1B: Felix Washington | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (93.7 mph), freezes him on the inner edge. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (81.3 mph), right down the middle. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 1 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.4 mph), freezes him on the inner edge. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (93.4 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.2 mph), way outside. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (93.9 mph), catches the black. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 2B: Leo Vance, 1B: Jackson Riley | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (93.5 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 2B: Leo Vance, 1B: Jackson Riley | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Sinker (93.0 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Sinker (93.0 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Sinker (93.8 mph), paints the corner. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.8 mph), sails over the letters. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (93.6 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.0 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.0 mph), just misses outside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (93.2 mph), right down the middle. Foul. Count: 2-2
+  Pitch: Four-Seam Fastball (93.7 mph), sails over the letters. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (93.8 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (94.0 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Curveball (80.6 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Curveball (81.5 mph), drops onto the knees. Rolls it over on the ground.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Sinker (93.8 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (91.5 mph), a bit inside. Ball. Count: 2-0
+  Pitch: Slider (87.2 mph), in the dirt. Ball. Count: 3-0
+  Pitch: Sinker (92.0 mph), a bit inside. Ball.
+Result: Walk         | Outs: 0 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Sinker (92.5 mph), paints the corner. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 2B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Sinker (92.7 mph), high and tight. Swinging Strike. Count: 0-1
+  Pitch: Sinker (91.2 mph), snaps over the backdoor. Swinging Strike. Count: 0-2
+  Pitch: Sinker (93.9 mph), paints the corner. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: 2B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (87.3 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Slider (87.0 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Sinker (91.9 mph), low and away. Ball. Count: 2-1
+  Pitch: Sinker (91.7 mph), high and tight. Ball. Count: 3-1
+  Pitch: Sinker (92.7 mph), drops onto the knees. Called Strike. Count: 3-2
+  Pitch: Slider (87.9 mph), in the zone. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: 2B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (86.3 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Slider (87.4 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Slider (86.5 mph), low and away. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 2B: Kevin Webb, 1B: Omar Ramirez | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Four-Seam Fastball (93.5 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.3 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.1 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.9 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (95.4 mph), just misses outside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.6 mph), catches the black. Called Strike. Count: 0-2
+  Pitch: Curveball (80.6 mph), a perfect strike. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (80.4 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.7 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Curveball (80.4 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Curveball (80.2 mph), a perfect strike. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.9 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 3 - Pacific City Pilots 6
+
+Pacific City Pilots win!

--- a/examples/game_09.txt
+++ b/examples/game_09.txt
@@ -1,0 +1,551 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 55°F, Drizzle
+Umpires: HP: Larry Phillips, 1B: Stan Friedman, 2B: Chuck Thompson, 3B: Gus Morales
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (95.3 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (89.5 mph), catches the black. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.1 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Four-Seam Fastball (95.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Slider (88.5 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Slider (89.7 mph), high and tight. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (95.7 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 2B: Kevin Webb | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (81.7 mph), in the dirt. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.2 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.1 mph), high and tight. Ball. Count: 2-1
+  Pitch: Changeup (81.6 mph), low and away. Ball. Count: 3-1
+  Pitch: Four-Seam Fastball (95.0 mph), a perfect strike. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Slider (88.3 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.6 mph), paints the corner. Called Strike. Count: 0-2
+  Pitch: Changeup (82.5 mph), drops onto the knees. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Changeup (83.3 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Curveball (78.8 mph), snaps over the backdoor. Laces a ringing double off the wall!
+Result: Double       | Outs: 2 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Curveball (79.9 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 3B: Evan Reed, 2B: Felix Washington | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Curveball (78.2 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Curveball (79.9 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Slider (85.4 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Slider (85.9 mph), low and away. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Slider (84.4 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 3B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Sam Decker (C, R)
+  Pitch: Two-Seam Fastball (90.4 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: 3B: Leo Vance, 1B: Marcus Thorne | Score: Bay Area Bombers: 0, Pacific City Pilots: 2
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Quick throw to first and Marcus Thorne dives back safely.
+  Pitch: Two-Seam Fastball (92.5 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.9 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (91.8 mph), a bit inside. Ball. Count: 2-1
+  Wild Pitch! Runners advance.
+  Leo Vance scores!
+  Pitch: Curveball (80.1 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (91.1 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Marcus Thorne | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (90.3 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.8 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Slider (86.1 mph), freezes him on the inner edge. Foul. Count: 2-1
+  Pitch: Two-Seam Fastball (90.6 mph), just misses outside. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (92.4 mph), high and tight. Ball.
+Result: Walk         | Outs: 2 | Bases: 3B: Marcus Thorne, 1B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.2 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 3B: Marcus Thorne, 1B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (95.5 mph), a perfect strike. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Four-Seam Fastball (96.3 mph), freezes him on the inner edge. Called Strike. Count: 0-1
+  Pitch: Changeup (81.7 mph), low and away. Ball. Count: 1-1
+  Pitch: Changeup (83.6 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.0 mph), right down the middle. Foul. Count: 2-2
+  Pitch: Slider (87.7 mph), in the dirt. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (94.1 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 1 | Bases: 3B: Wes Griffin, 2B: Alex Chase | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (82.0 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: 3B: Wes Griffin, 2B: Alex Chase | Score: Bay Area Bombers: 1, Pacific City Pilots: 2
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (87.3 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Changeup (81.8 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.5 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (95.6 mph), spikes before the plate. Ball. Count: 3-1
+  Pitch: Changeup (83.6 mph), catches the black. Foul. Count: 3-2
+  Pitch: Changeup (82.0 mph), catches the black. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Omar Ramirez | Score: Bay Area Bombers: 1, Pacific City Pilots: 4
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.6 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.1 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Slider (87.1 mph), paints the corner. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Curveball (78.1 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Curveball (79.6 mph), freezes him on the inner edge. Lifts a routine fly ball.
+  An error by LF Grant Fisher allows the batter to reach base.
+Result: Reached on Error (E7) | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (87.8 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.6 mph), paints the corner. Swinging Strike. Count: 1-1
+  Pitch: Slider (87.3 mph), freezes him on the inner edge. Swinging Strike. Count: 1-2
+  Pitch: Slider (89.8 mph), low and away. Ball. Count: 2-2
+  Pitch: Changeup (82.3 mph), catches the black. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.9 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (86.2 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Slider (84.3 mph), paints the corner. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (90.2 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Slider (85.8 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.9 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (92.7 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: Hank Barrett (C, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Slider (88.2 mph), low and away. Ball. Count: 1-0
+  Pitch: Changeup (82.4 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (80.5 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Curveball (78.8 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (95.1 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Slider (88.0 mph), in the dirt. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Changeup (83.6 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 3B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (78.8 mph), snaps over the backdoor. Called Strike. Count: 0-1
+  Pitch: Slider (89.7 mph), catches the black. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.3 mph), in the dirt. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (95.9 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 3B: Hank Barrett | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (92.3 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (92.8 mph), catches the black. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.9 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.4 mph), a bit inside. Ball. Count: 1-2
+  Pitch: Slider (87.0 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Two-Seam Fastball (90.1 mph), just misses outside. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (84.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.8 mph), snaps over the backdoor. Foul. Count: 1-1
+  Pitch: Slider (86.6 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Slider (86.3 mph), way outside. Ball. Count: 2-2
+  Pitch: Slider (85.3 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 1B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (78.5 mph), catches the black. Foul. Count: 0-1
+  Pitch: Curveball (78.6 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.5 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 1B: Sam Decker | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (82.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.5 mph), a bit inside. Ball. Count: 2-0
+  Pitch: Four-Seam Fastball (94.6 mph), sails over the letters. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (94.3 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.1 mph), catches the black. Foul. Count: 1-1
+  Pitch: Slider (87.1 mph), paints the corner. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (95.6 mph), way outside. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (96.8 mph), paints the corner. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (95.0 mph), right down the middle. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (95.7 mph), low and away. Ball. Count: 1-0
+  Pitch: Curveball (78.1 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.6 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (79.4 mph), in the zone. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.3 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Curveball (79.4 mph), paints the corner. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Curveball (80.0 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.8 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (92.8 mph), just misses outside. Swinging Strike. Count: 2-1
+  Pitch: Curveball (80.7 mph), way outside. Ball. Count: 3-1
+  Pitch: Slider (85.6 mph), catches the black. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (85.0 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.9 mph), just misses outside. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (91.3 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 3B: Nate Diaz, 2B: Owen Chen, 1B: Miles Corbin | Score: Bay Area Bombers: 1, Pacific City Pilots: 6
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (79.1 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Slider (84.5 mph), catches the black. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Owen Chen, 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Two-Seam Fastball (91.9 mph), right down the middle. Lifts a routine fly ball.
+Result: Pop out to 2B (P4) | Outs: 2 | Bases: 3B: Owen Chen, 2B: Miles Corbin, 1B: Grant Fisher | Score: Bay Area Bombers: 2, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Two-Seam Fastball (90.4 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (79.1 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Slider (87.0 mph), a perfect strike. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 3B: Miles Corbin, 2B: Grant Fisher, 1B: Marcus Thorne | Score: Bay Area Bombers: 3, Pacific City Pilots: 6
+
+Now batting: Sam Decker (C, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (79.6 mph), snaps over the backdoor. Hooks a double down the line!
+Result: Double       | Outs: 2 | Bases: 3B: Marcus Thorne, 2B: Sam Decker | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.2 mph), catches the black. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: 3B: Marcus Thorne, 2B: Sam Decker | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (87.9 mph), catches the black. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.7 mph), spikes before the plate. Ball. Count: 1-1
+  Pitch: Curveball (80.9 mph), way outside. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (94.2 mph), snaps over the backdoor. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (95.8 mph), sails over the letters. Foul. Count: 0-1
+  Pitch: Slider (89.0 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Changeup (83.8 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (78.2 mph), drops onto the knees. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (78.4 mph), in the dirt. Foul. Count: 0-1
+  Pitch: Curveball (80.8 mph), paints the corner. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (91.9 mph), way outside. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.1 mph), way outside. Hammers a double into the gap!
+Result: Double       | Outs: 1 | Bases: 3B: Nate Diaz, 2B: Owen Chen | Score: Bay Area Bombers: 5, Pacific City Pilots: 6
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (78.8 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (78.6 mph), way outside. Ball. Count: 2-0
+  Pitch: Curveball (80.8 mph), drops onto the knees. Foul. Count: 2-1
+  Pitch: Curveball (78.3 mph), catches the black. Foul. Count: 2-2
+  Pitch: Curveball (79.3 mph), in the dirt. Ball. Count: 3-2
+  Pitch: Slider (84.9 mph), paints the corner. Lifts a routine fly ball.
+  Sacrifice fly to RF, Nate Diaz scores!
+Result: Flyout to RF (F9 (SF)) | Outs: 2 | Bases: 2B: Owen Chen | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (90.7 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.8 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (92.8 mph), drops onto the knees. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 2B: Owen Chen | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Defensive alignment: Outfield shifts toward right-center.
+  Pitch: Changeup (81.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Changeup (81.2 mph), drops onto the knees. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (95.3 mph), freezes him on the inner edge. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.2 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Changeup (83.7 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (95.1 mph), freezes him on the inner edge. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Knuckle-Curve (78.8 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.5 mph), right down the middle. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Miguel Garcia ---
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.6 mph), a bit inside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.5 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Curveball (79.5 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.7 mph), a perfect strike. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Four-Seam Fastball (95.4 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to RF (F9) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.3 mph), a bit inside. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.4 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to 3B (5-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (92.8 mph), right down the middle. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (93.8 mph), way outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (93.2 mph), snaps over the backdoor. Foul. Count: 1-2
+  Pitch: Knuckle-Curve (77.0 mph), right down the middle. Called Strike.
+Result: Strikeout    | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Evan Reed (LF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Knuckle-Curve (79.4 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.0 mph), low and away. Ball. Count: 1-1
+  Pitch: Knuckle-Curve (77.8 mph), way outside. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (92.5 mph), just misses outside. Shoots a single through the right side!
+Result: Single       | Outs: 2 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 6, Pacific City Pilots: 6
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Quick throw to first and Evan Reed dives back safely.
+  Pitch: Knuckle-Curve (79.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Knuckle-Curve (79.3 mph), right down the middle. Swinging Strike. Count: 1-1
+  Pitch: Knuckle-Curve (78.6 mph), in the zone. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (93.3 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (81.7 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.6 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (95.3 mph), high and tight. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (93.2 mph), a perfect strike. Swinging Strike. Count: 2-2
+  Pitch: Four-Seam Fastball (94.7 mph), spikes before the plate. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (95.6 mph), drops onto the knees. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Caleb Jones (SS, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (81.6 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.3 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (93.8 mph), paints the corner. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.2 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.5 mph), just misses outside. Ball. Count: 3-2
+  Pitch: Curveball (79.6 mph), high and tight. Ball.
+Result: Walk         | Outs: 1 | Bases: 1B: Caleb Jones | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Curveball (80.1 mph), low and away. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 2B: Caleb Jones, 1B: Nate Diaz | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Four-Seam Fastball (95.9 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.2 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 3B: Caleb Jones, 2B: Nate Diaz | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Four-Seam Fastball (94.8 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Curveball (79.4 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.4 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 3B: Caleb Jones, 2B: Nate Diaz | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Wes Griffin (SS, S)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (93.8 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Knuckle-Curve (79.2 mph), freezes him on the inner edge. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Knuckle-Curve (79.1 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (92.2 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 2B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.5 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.8 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.3 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Knuckle-Curve (78.0 mph), right down the middle. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 2B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Knuckle-Curve (77.8 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: 2B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 6, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Grant Fisher (LF, R)
+  Pitch: Curveball (79.0 mph), in the zone. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (94.2 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.4 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (95.0 mph), high and tight. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 7, Pacific City Pilots: 8
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (81.0 mph), way outside. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), paints the corner. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.1 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.9 mph), drops onto the knees. Called Strike. Count: 0-2
+  Pitch: Curveball (79.7 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (94.0 mph), paints the corner. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (87.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (92.4 mph), in the dirt. Ball. Count: 2-0
+  Pitch: Sinker (93.2 mph), snaps over the backdoor. Swinging Strike. Count: 2-1
+  Pitch: Slider (86.1 mph), low and away. Ball. Count: 3-1
+  Pitch: Sinker (91.3 mph), snaps over the backdoor. Swinging Strike. Count: 3-2
+  Pitch: Sinker (93.9 mph), right down the middle. Hammers a double into the gap!
+Result: Double       | Outs: 0 | Bases: 2B: Rex Power | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Sinker (92.6 mph), right down the middle. Called Strike. Count: 0-1
+  Pitch: Sinker (93.9 mph), a perfect strike. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 1 | Bases: 2B: Rex Power | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (93.4 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Slider (87.0 mph), catches the black. Swinging Strike. Count: 1-1
+  Pitch: Sinker (93.3 mph), catches the black. Called Strike. Count: 1-2
+  Pitch: Sinker (92.0 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Slider (86.8 mph), catches the black. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 2B: Rex Power | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Sinker (93.9 mph), way outside. Ball. Count: 1-0
+  Pitch: Sinker (92.8 mph), in the zone. Swinging Strike. Count: 1-1
+  Pitch: Sinker (91.6 mph), spikes before the plate. Ball. Count: 2-1
+  Pitch: Sinker (92.3 mph), high and tight. Ball. Count: 3-1
+  Pitch: Sinker (91.4 mph), in the zone. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Rex Power | Score: Bay Area Bombers: 8, Pacific City Pilots: 8
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Caleb Jones (SS, R)
+  Pitch: Four-Seam Fastball (94.3 mph), catches the black. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 8
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 9 - Pacific City Pilots 8
+
+Bay Area Bombers win!

--- a/examples/game_10.txt
+++ b/examples/game_10.txt
@@ -1,0 +1,579 @@
+==================== GAME START ====================
+Pacific City Pilots vs. Bay Area Bombers
+Venue: Waterfront Park
+Weather: 68°F, Overcast
+Umpires: HP: Chuck Thompson, 1B: Gus Morales, 2B: Stan Friedman, 3B: Larry Phillips
+--------------------------------------------------
+--------------------------------------------------
+Top of Inning 1 | Pacific City Pilots batting
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.6 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (96.7 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.7 mph), in the zone. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.6 mph), freezes him on the inner edge. Swinging Strike. Count: 1-2
+  Pitch: Changeup (82.6 mph), way outside. Ball. Count: 2-2
+  Pitch: Changeup (84.0 mph), way outside. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Slider (89.7 mph), low and away. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.3 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 2 | Bases: 3B: Alex Chase | Score: Bay Area Bombers: 0, Pacific City Pilots: 0
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (89.1 mph), low and away. Skies it to the outfield.
+  An error by RF Marcus Thorne allows the batter to reach base.
+Result: Reached on Error (E9) | Outs: 2 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Four-Seam Fastball (96.2 mph), high and tight. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 1B: Rex Power | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 1 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (84.2 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.2 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Two-Seam Fastball (91.6 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (86.8 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 0, Pacific City Pilots: 1
+
+Now batting: Sam Decker (C, R)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Slider (84.0 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Curveball (80.7 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Two-Seam Fastball (90.8 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (90.1 mph), a perfect strike. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Curveball (80.9 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Two-Seam Fastball (90.5 mph), a bit inside. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (92.7 mph), high and tight. Ball. Count: 1-2
+  Pitch: Two-Seam Fastball (90.3 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Slider (86.2 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+  An error by SS Wes Griffin allows the batter to reach base.
+Result: Reached on Error (E6) | Outs: 2 | Bases: 1B: Jackson Riley | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (91.5 mph), high and tight. Ball. Count: 1-0
+  Pitch: Curveball (79.8 mph), paints the corner. Swinging Strike. Count: 1-1
+  Pitch: Curveball (79.0 mph), way outside. Ball. Count: 2-1
+  Pitch: Curveball (78.1 mph), a bit inside. Ball. Count: 3-1
+  Pitch: Two-Seam Fastball (91.5 mph), way outside. Ball.
+Result: Walk         | Outs: 2 | Bases: 2B: Jackson Riley, 1B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (90.3 mph), low and away. Ball. Count: 1-0
+  Pitch: Slider (86.0 mph), in the zone. Called Strike. Count: 1-1
+  Pitch: Curveball (78.3 mph), high and tight. Foul. Count: 1-2
+  Pitch: Two-Seam Fastball (90.3 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Jackson Riley, 1B: Caleb Jones | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 2 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Slider (89.3 mph), sails over the letters. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (95.5 mph), paints the corner. Swinging Strike. Count: 1-1
+  Pitch: Four-Seam Fastball (95.8 mph), just misses outside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (94.2 mph), in the zone. Foul. Count: 2-2
+  Pitch: Changeup (82.5 mph), catches the black. Called Strike.
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Four-Seam Fastball (96.9 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), snaps over the backdoor. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (94.8 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Four-Seam Fastball (94.7 mph), sails over the letters. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 2 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Slider (86.5 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (91.5 mph), paints the corner. Swinging Strike. Count: 0-2
+  Pitch: Two-Seam Fastball (91.4 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Slider (86.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.5 mph), low and away. Ball. Count: 2-0
+  Pitch: Two-Seam Fastball (90.6 mph), a bit inside. Foul. Count: 2-1
+  Pitch: Curveball (80.6 mph), just misses outside. Foul. Count: 2-2
+  Pitch: Two-Seam Fastball (90.6 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (92.4 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Two-Seam Fastball (92.3 mph), in the zone. Swinging Strike. Count: 0-2
+  Pitch: Slider (84.4 mph), a perfect strike. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 3 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Defensive alignment: Middle infielders pinch the bag.
+  Pitch: Changeup (81.6 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Changeup (83.0 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Slider (88.0 mph), just misses outside. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Curveball (80.7 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), catches the black. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (96.2 mph), sails over the letters. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (94.4 mph), a bit inside. Chops a bouncer toward the infield.
+Result: Comebacker handled by the pitcher (1-3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Changeup (81.8 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.7 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Changeup (81.3 mph), snaps over the backdoor. Skies it to the outfield.
+Result: Pop out to 3B (P5) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 3 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (84.8 mph), high and tight. Ball. Count: 1-0
+  Pitch: Slider (86.4 mph), a perfect strike. Swinging Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (92.1 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (90.1 mph), sails over the letters. Ball. Count: 3-1
+  Pitch: Slider (84.7 mph), spikes before the plate. Ball.
+Result: Walk         | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Curveball (79.0 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Sam Decker (C, R)
+  Pitch: Slider (86.5 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Curveball (80.6 mph), high and tight. Ball. Count: 1-1
+  Pitch: Two-Seam Fastball (91.9 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Curveball (80.2 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 2 | Bases: 2B: Leo Vance | Score: Bay Area Bombers: 1, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (91.6 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Curveball (78.3 mph), spikes before the plate. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Two-Seam Fastball (92.1 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Curveball (80.1 mph), freezes him on the inner edge. Called Strike. Count: 1-1
+  Pitch: Two-Seam Fastball (91.2 mph), a bit inside. Ball. Count: 2-1
+  Pitch: Two-Seam Fastball (91.6 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Curveball (80.1 mph), drops onto the knees. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 4 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.6 mph), drops onto the knees. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Omar Ramirez | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Slider (88.2 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (96.7 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+  An error by 2B Nate Diaz allows the batter to reach base.
+Result: Reached on Error (E4) | Outs: 0 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Changeup (83.1 mph), just misses outside. Foul. Count: 0-1
+  Pitch: Slider (88.8 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Changeup (82.5 mph), right down the middle. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 1 | Bases: 3B: Omar Ramirez, 2B: Rex Power | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Four-Seam Fastball (94.6 mph), high and tight. Ball. Count: 1-0
+  Pitch: Changeup (83.5 mph), a perfect strike. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Swinging Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (96.9 mph), low and away. Ball. Count: 2-2
+  Pitch: Curveball (79.5 mph), right down the middle. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 3B: Omar Ramirez, 2B: Rex Power | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Curveball (78.2 mph), way outside. Ball. Count: 1-0
+  Pitch: Slider (87.9 mph), paints the corner. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (96.4 mph), right down the middle. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (96.2 mph), in the dirt. Ball. Count: 2-2
+  Pitch: Changeup (83.1 mph), way outside. Ball. Count: 3-2
+  Pitch: Four-Seam Fastball (96.1 mph), just misses outside. Ball.
+Result: Walk         | Outs: 2 | Bases: 3B: Omar Ramirez, 2B: Rex Power, 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Slider (87.1 mph), just misses outside. Skies it to the outfield.
+Result: Pop out to SS (P6) | Outs: 3 | Bases: 3B: Omar Ramirez, 2B: Rex Power, 1B: Hank Barrett | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 4 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (91.1 mph), low and away. Lifts a routine fly ball.
+  An error by CF Kevin Webb allows the batter to reach base.
+Result: Reached on Error (E8) | Outs: 0 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Two-Seam Fastball (92.4 mph), in the zone. Swinging Strike. Count: 0-1
+  Pitch: Curveball (78.5 mph), in the zone. Foul. Count: 0-2
+  Pitch: Curveball (80.2 mph), way outside. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Curveball (79.7 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Curveball (78.9 mph), catches the black. Lifts a routine fly ball.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: 2B: Nate Diaz, 1B: Owen Chen | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Two-Seam Fastball (91.4 mph), just misses outside. Ball. Count: 1-0
+  Pitch: Slider (84.1 mph), freezes him on the inner edge. Swinging Strike. Count: 1-1
+  Pitch: Curveball (78.4 mph), in the zone. Called Strike. Count: 1-2
+  Pitch: Curveball (79.1 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 1 | Bases: 3B: Nate Diaz, 2B: Owen Chen, 1B: Grant Fisher | Score: Bay Area Bombers: 2, Pacific City Pilots: 1
+
+Now batting: Leo Vance (CF, L)
+  Quick throw to first and Grant Fisher dives back safely.
+  Pitch: Curveball (80.1 mph), in the zone. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Owen Chen, 2B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Pitch: Two-Seam Fastball (91.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (90.2 mph), spikes before the plate. Skies it to the outfield.
+Result: Flyout to RF (F9) | Outs: 3 | Bases: 3B: Owen Chen, 2B: Grant Fisher | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 5 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (88.6 mph), drops onto the knees. Called Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (94.9 mph), catches the black. Foul. Count: 0-2
+  Pitch: Four-Seam Fastball (94.8 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (96.0 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.8 mph), in the zone. Skies it to the outfield.
+Result: Flyout to LF (F7) | Outs: 1 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.4 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (96.3 mph), drops onto the knees. Foul. Count: 0-2
+  Pitch: Changeup (83.2 mph), just misses outside. Ball. Count: 1-2
+  Pitch: Four-Seam Fastball (95.4 mph), snaps over the backdoor. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 2 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Four-Seam Fastball (95.0 mph), snaps over the backdoor. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.4 mph), snaps over the backdoor. Foul. Count: 0-2
+  Pitch: Slider (87.6 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 2B: TJ Hawkins, 1B: Omar Ramirez | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Changeup (81.8 mph), catches the black. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.6 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Changeup (82.4 mph), way outside. Ball. Count: 2-1
+  Pitch: Four-Seam Fastball (95.1 mph), high and tight. Ball. Count: 3-1
+  Pitch: Four-Seam Fastball (96.7 mph), high and tight. Ball.
+Result: Walk         | Outs: 2 | Bases: 3B: TJ Hawkins, 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Quick throw to first and Rex Power dives back safely.
+  Pitch: Slider (88.8 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (95.0 mph), in the dirt. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (96.1 mph), in the zone. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (96.7 mph), spikes before the plate. Ball. Count: 2-2
+  Pitch: Four-Seam Fastball (94.6 mph), right down the middle. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 3B: TJ Hawkins, 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 5 | Bay Area Bombers batting
+Now batting: Sam Decker (C, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Curveball (78.8 mph), in the zone. Foul. Count: 0-1
+  Pitch: Curveball (79.5 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Slider (86.7 mph), drops onto the knees. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Two-Seam Fastball (92.4 mph), low and away. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (92.7 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Caleb Jones (SS, R)
+  Pitch: Curveball (79.2 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Two-Seam Fastball (91.1 mph), paints the corner. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 6 | Pacific City Pilots batting
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Changeup (83.9 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Curveball (78.4 mph), a perfect strike. Swinging Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (96.7 mph), a bit inside. Ball. Count: 1-2
+  Pitch: Slider (88.1 mph), drops onto the knees. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Hank Barrett (C, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (88.4 mph), high and tight. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), catches the black. Called Strike. Count: 1-1
+  Pitch: Changeup (83.3 mph), right down the middle. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (95.1 mph), catches the black. Skies it to the outfield.
+Result: Pop out to 1B (P3) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+
+--- Pitching Change for Bay Area Bombers: Adam Adams replaces Joe Gibson ---
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Knuckle-Curve (77.4 mph), a perfect strike. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 6 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Two-Seam Fastball (92.2 mph), snaps over the backdoor. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Nate Diaz | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+
+--- Pitching Change for Pacific City Pilots: Rollie Malone replaces Miguel Garcia ---
+
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Quick throw to first and Nate Diaz dives back safely.
+  Pitch: Slider (87.4 mph), drops onto the knees. Swinging Strike. Count: 0-1
+  Pitch: Sinker (91.7 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: 2B: Nate Diaz | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Sinker (90.6 mph), right down the middle. Swinging Strike. Count: 0-1
+  Pitch: Sinker (90.3 mph), paints the corner. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 2 | Bases: 3B: Nate Diaz | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Slider (85.2 mph), snaps over the backdoor. Swinging Strike. Count: 0-1
+  Pitch: Sinker (90.9 mph), right down the middle. Foul. Count: 0-2
+  Pitch: Slider (87.4 mph), in the zone. Chops a bouncer toward the infield.
+Result: Groundout to 2B (4-3) | Outs: 3 | Bases: 3B: Nate Diaz | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 7 | Pacific City Pilots batting
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Knuckle-Curve (78.4 mph), a perfect strike. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (78.1 mph), sails over the letters. Foul. Count: 0-2
+  Pitch: Knuckle-Curve (79.4 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: TJ Hawkins | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Four-Seam Fastball (92.0 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.1 mph), high and tight. Rolls it over on the ground.
+  Ground ball to second... 4-6-3 double play!
+Result: Groundout, Double Play (GDP (4-6-3)) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+  Pitch: Four-Seam Fastball (94.1 mph), in the zone. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (80.0 mph), a perfect strike. Lifts a routine fly ball.
+Result: Flyout to LF (F7) | Outs: 3 | Bases: Bases empty | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+--------------------------------------------------
+Bottom of Inning 7 | Bay Area Bombers batting
+Now batting: Leo Vance (CF, L)
+  Pitch: Slider (87.3 mph), low and away. Ball. Count: 1-0
+  Pitch: Sinker (92.3 mph), freezes him on the inner edge. Foul. Count: 1-1
+  Pitch: Sinker (90.5 mph), a perfect strike. Foul. Count: 1-2
+  Pitch: Slider (85.1 mph), right down the middle. Shoots a single through the right side!
+Result: Single       | Outs: 0 | Bases: 1B: Leo Vance | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Marcus Thorne (RF, L)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Slider (87.4 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (91.7 mph), snaps over the backdoor. Called Strike. Count: 1-1
+  Pitch: Sinker (91.5 mph), a bit inside. Hooks a double down the line!
+Result: Double       | Outs: 0 | Bases: 3B: Leo Vance, 2B: Marcus Thorne | Score: Bay Area Bombers: 3, Pacific City Pilots: 1
+
+Now batting: Sam Decker (C, R)
+  Pitch: Sinker (90.3 mph), freezes him on the inner edge. Foul. Count: 0-1
+  Pitch: Slider (87.9 mph), snaps over the backdoor. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 0 | Bases: 3B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 1
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Slider (85.9 mph), high and tight. Ball. Count: 1-0
+  Pitch: Sinker (92.9 mph), right down the middle. Foul. Count: 1-1
+  Pitch: Sinker (91.1 mph), catches the black. Swinging Strike. Count: 1-2
+  Pitch: Sinker (91.1 mph), sails over the letters. Ball. Count: 2-2
+  Pitch: Sinker (91.5 mph), sails over the letters. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: 3B: Marcus Thorne, 1B: Sam Decker | Score: Bay Area Bombers: 4, Pacific City Pilots: 1
+
+Now batting: Caleb Jones (SS, R)
+  Defensive alignment: Infield shades to pull on the left side.
+  Pitch: Sinker (90.5 mph), in the zone. Called Strike. Count: 0-1
+  Pitch: Sinker (91.7 mph), sails over the letters. Ball. Count: 1-1
+  Pitch: Slider (87.2 mph), freezes him on the inner edge. Foul. Count: 1-2
+  Pitch: Sinker (91.8 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 3B (5-3) | Outs: 2 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Slider (87.3 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Sinker (92.7 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to SS (6-3) | Outs: 3 | Bases: 2B: Sam Decker | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+--------------------------------------------------
+Top of Inning 8 | Pacific City Pilots batting
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Knuckle-Curve (78.7 mph), catches the black. Foul. Count: 0-1
+  Pitch: Knuckle-Curve (80.0 mph), snaps over the backdoor. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 1B: Omar Ramirez | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Rex Power 'Buzz' (DH, R)
+  Pitch: Four-Seam Fastball (94.7 mph), a perfect strike. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (93.1 mph), way outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (92.7 mph), in the dirt. Ball. Count: 2-1
+  Pitch: Knuckle-Curve (78.5 mph), just misses outside. Ball. Count: 3-1
+  Pitch: Knuckle-Curve (79.2 mph), right down the middle. Called Strike. Count: 3-2
+  Pitch: Knuckle-Curve (78.0 mph), snaps over the backdoor. Stings a single back up the middle!
+Result: Single       | Outs: 0 | Bases: 2B: Omar Ramirez, 1B: Rex Power | Score: Bay Area Bombers: 5, Pacific City Pilots: 1
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Knuckle-Curve (79.0 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (78.0 mph), just misses outside. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (92.5 mph), drops onto the knees. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Knuckle-Curve (79.4 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Knuckle-Curve (77.7 mph), right down the middle. Called Strike. Count: 0-2
+  Pitch: Four-Seam Fastball (93.5 mph), freezes him on the inner edge. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Knuckle-Curve (78.9 mph), in the dirt. Ball. Count: 1-0
+  Pitch: Four-Seam Fastball (94.9 mph), catches the black. Called Strike. Count: 1-1
+  Pitch: Knuckle-Curve (78.8 mph), catches the black. Foul. Count: 1-2
+  Pitch: Four-Seam Fastball (92.9 mph), paints the corner. Rolls it over on the ground.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+
+--- Pitching Change for Bay Area Bombers: Colin Miller replaces Adam Adams ---
+
+Now batting: Wes Griffin (SS, S)
+  Pitch: Sinker (93.5 mph), spikes before the plate. Foul. Count: 0-1
+  Pitch: Sinker (92.0 mph), freezes him on the inner edge. Foul. Count: 0-2
+  Pitch: Sinker (93.9 mph), a bit inside. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 2 | Bases: 1B: Wes Griffin | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+Now batting: TJ Hawkins (RF, R)
+  Pitch: Slider (88.0 mph), high and tight. Ball. Count: 1-0
+  Pitch: Sinker (93.6 mph), right down the middle. Rolls it over on the ground.
+  An error by P Colin Miller allows the batter to reach base.
+Result: Reached on Error (E1) | Outs: 2 | Bases: 2B: Wes Griffin, 1B: TJ Hawkins | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+Now batting: Alex Chase (2B, R)
+  Pitch: Sinker (91.1 mph), in the zone. Stings a single back up the middle!
+Result: Single       | Outs: 2 | Bases: 3B: Wes Griffin, 2B: TJ Hawkins, 1B: Alex Chase | Score: Bay Area Bombers: 5, Pacific City Pilots: 4
+
+Now batting: Kevin Webb 'Spider' (CF, L)
+Result: Hit by Pitch | Outs: 2 | Bases: 3B: TJ Hawkins, 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 5, Pacific City Pilots: 5
+
+Now batting: Omar Ramirez 'Cookie' (3B, R)
+  Pitch: Sinker (92.7 mph), right down the middle. Foul. Count: 0-1
+  Pitch: Sinker (91.3 mph), paints the corner. Foul. Count: 0-2
+  Pitch: Sinker (93.9 mph), right down the middle. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 3 | Bases: 3B: TJ Hawkins, 2B: Alex Chase, 1B: Kevin Webb | Score: Bay Area Bombers: 5, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 8 | Bay Area Bombers batting
+Now batting: Owen Chen 'Big Duck' (1B, L)
+  Pitch: Sinker (91.4 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Sinker (92.9 mph), a bit inside. Crushes a towering homer into the seats!
+Result: Home Run     | Outs: 0 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Miles Corbin (3B, S)
+  Pitch: Sinker (91.9 mph), paints the corner. Foul. Count: 0-1
+  Pitch: Sinker (90.8 mph), high and tight. Ball. Count: 1-1
+  Pitch: Slider (87.9 mph), snaps over the backdoor. Rolls it over on the ground.
+Result: Groundout to SS (6-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+
+--- Pitching Change for Pacific City Pilots: Ben Logan replaces Rollie Malone ---
+
+Now batting: Grant Fisher (LF, R)
+  Pitch: Four-Seam Fastball (93.9 mph), freezes him on the inner edge. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Grant Fisher | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Leo Vance (CF, L)
+  Pitch: Four-Seam Fastball (93.2 mph), in the zone. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (94.0 mph), right down the middle. Drops a blooper into shallow center for a single!
+Result: Single       | Outs: 1 | Bases: 2B: Grant Fisher, 1B: Leo Vance | Score: Bay Area Bombers: 6, Pacific City Pilots: 5
+
+Now batting: Marcus Thorne (RF, L)
+  Defensive alignment: Corners creep in expecting a bunt.
+  Pitch: Four-Seam Fastball (93.2 mph), freezes him on the inner edge. Swinging Strike. Count: 0-1
+  Pitch: Four-Seam Fastball (95.8 mph), right down the middle. Launches it deep and out of here for a home run!
+Result: Home Run     | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Sam Decker (C, R)
+  Pitch: Four-Seam Fastball (93.6 mph), paints the corner. Called Strike. Count: 0-1
+  Pitch: Curveball (81.1 mph), a perfect strike. Foul. Count: 0-2
+  Pitch: Curveball (81.5 mph), paints the corner. Lifts a routine fly ball.
+Result: Pop out to 3B (P5) | Outs: 2 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Jackson Riley 'Jax' (DH, R)
+  Pitch: Four-Seam Fastball (95.7 mph), spikes before the plate. Ball. Count: 1-0
+  Pitch: Curveball (79.9 mph), just misses outside. Foul. Count: 1-1
+  Pitch: Four-Seam Fastball (94.3 mph), in the zone. Hammers a double into the gap!
+Result: Double       | Outs: 2 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Caleb Jones (SS, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Four-Seam Fastball (94.9 mph), catches the black. Skies it to the outfield.
+Result: Flyout to CF (F8) | Outs: 3 | Bases: 2B: Jackson Riley | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+--------------------------------------------------
+Top of Inning 9 | Pacific City Pilots batting
+Now batting: Rex Power 'Buzz' (DH, R)
+  Brief delay as the infield huddles on the mound.
+  Pitch: Sinker (93.9 mph), drops onto the knees. Foul. Count: 0-1
+  Pitch: Sinker (93.3 mph), freezes him on the inner edge. Called Strike. Count: 0-2
+  Pitch: Sinker (92.0 mph), catches the black. Swinging Strike (Whiff).
+Result: Strikeout    | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Evan Reed (LF, L)
+  Pitch: Sinker (92.5 mph), paints the corner. Swinging Strike. Count: 0-1
+  Pitch: Slider (86.1 mph), high and tight. Ball. Count: 1-1
+  Pitch: Slider (86.8 mph), sails over the letters. Ball. Count: 2-1
+  Pitch: Sinker (92.9 mph), snaps over the backdoor. Foul. Count: 2-2
+  Pitch: Slider (87.2 mph), high and tight. Ball. Count: 3-2
+  Pitch: Slider (87.3 mph), drops onto the knees. Stings a single back up the middle!
+Result: Single       | Outs: 1 | Bases: 1B: Evan Reed | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Felix Washington 'Nine' (1B, L)
+  Pitch: Sinker (92.8 mph), freezes him on the inner edge. Chops a bouncer toward the infield.
+Result: Groundout to 1B (3U) | Outs: 2 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+Now batting: Hank Barrett (C, R)
+  Pitch: Slider (87.5 mph), a perfect strike. Called Strike. Count: 0-1
+  Pitch: Sinker (93.8 mph), a bit inside. Ball. Count: 1-1
+  Pitch: Sinker (91.1 mph), low and away. Ball. Count: 2-1
+  Pitch: Sinker (91.7 mph), paints the corner. Foul. Count: 2-2
+  Pitch: Sinker (91.3 mph), catches the black. Called Strike.
+Result: Strikeout    | Outs: 3 | Bases: 2B: Evan Reed | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+--------------------------------------------------
+Bottom of Inning 9 | Bay Area Bombers batting
+Now batting: Nate Diaz 'Kid' (2B, R)
+  Pitch: Four-Seam Fastball (94.1 mph), low and away. Foul. Count: 0-1
+  Pitch: Four-Seam Fastball (93.9 mph), low and away. Ball. Count: 1-1
+  Pitch: Four-Seam Fastball (94.6 mph), freezes him on the inner edge. Called Strike. Count: 1-2
+  Pitch: Four-Seam Fastball (94.1 mph), spikes before the plate. Rolls it over on the ground.
+Result: Groundout to 2B (4-3) | Outs: 1 | Bases: Bases empty | Score: Bay Area Bombers: 9, Pacific City Pilots: 5
+
+==================== GAME OVER ====================
+
+Final Score: Bay Area Bombers 9 - Pacific City Pilots 5
+
+Bay Area Bombers win!

--- a/teams.py
+++ b/teams.py
@@ -19,11 +19,13 @@ GAME_CONTEXT = {
     "pitch_locations": {
         "strike": [
             "paints the corner", "right down the middle", "catches the black",
-            "a perfect strike", "in the zone"
+            "a perfect strike", "in the zone", "freezes him on the inner edge",
+            "snaps over the backdoor", "drops onto the knees"
         ],
         "ball": [
             "just misses outside", "high and tight", "in the dirt", "way outside",
-            "low and away", "a bit inside"
+            "low and away", "a bit inside", "sails over the letters",
+            "spikes before the plate"
         ]
     }
 }

--- a/test_examples_snapshot.py
+++ b/test_examples_snapshot.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+
+from example_games import EXAMPLE_GAMES, EXAMPLES_DIR
+
+
+class TestExampleSnapshots(unittest.TestCase):
+    def test_examples_match_rendered_output(self):
+        for index, game in enumerate(EXAMPLE_GAMES, start=1):
+            expected_path = EXAMPLES_DIR / f"game_{index:02d}.txt"
+            self.assertTrue(
+                expected_path.exists(),
+                msg=f"Missing example log for seed {game.seed}: {expected_path}",
+            )
+            expected_output = expected_path.read_text(encoding="utf-8")
+            actual_output = game.render()
+            self.assertEqual(
+                actual_output,
+                expected_output,
+                msg=f"Example log {expected_path} is out of date; rerun python update_examples.py.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_regression_realism.py
+++ b/test_regression_realism.py
@@ -1,0 +1,87 @@
+import io
+import random
+import unittest
+from contextlib import redirect_stdout
+
+from baseball import BaseballSimulator
+from teams import TEAMS
+
+
+class TestRegressionRealism(unittest.TestCase):
+    def setUp(self):
+        self.home = TEAMS["BAY_BOMBERS"]
+        self.away = TEAMS["PC_PILOTS"]
+
+    def test_catcher_groundouts_are_rare(self):
+        random.seed(123)
+        sim = BaseballSimulator(self.home, self.away, verbose_phrasing=False)
+        sim.top_of_inning = True
+
+        catcher_groundouts = 0
+        total_groundouts = 0
+
+        for _ in range(5000):
+            sim.outs = 0
+            sim.bases = [None, None, None]
+            desc, _, was_error = sim._handle_batted_ball_out("Groundout", sim.team2_lineup[0])
+            if was_error:
+                continue
+            total_groundouts += 1
+            if "2-3" in desc:
+                catcher_groundouts += 1
+
+        self.assertGreater(total_groundouts, 0)
+        rate = catcher_groundouts / total_groundouts
+        self.assertLess(
+            rate,
+            0.05,
+            f"Catchers handled {rate:.3%} of routine grounders; expected this to be a rare event."
+        )
+
+    def test_extra_innings_runner_banner_is_storylike(self):
+        random.seed(99)
+        sim = BaseballSimulator(self.home, self.away)
+        sim.inning = 10
+        sim.top_of_inning = False
+        sim.team1_batter_idx = 3
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            sim._simulate_half_inning()
+        log = buffer.getvalue()
+
+        self.assertNotIn("--- Extra Innings", log)
+        self.assertNotIn("placed on second base.", log)
+
+    def test_first_relief_usage_varies_by_game(self):
+        relievers_used = []
+        for seed in range(5):
+            random.seed(seed)
+            sim = BaseballSimulator(self.home, self.away)
+            starter = sim.team1_current_pitcher_name
+            sim.pitch_counts[starter] = sim.team1_pitcher_stats[starter]['stamina'] + 40
+            sim.top_of_inning = True
+            sim._manage_pitching_change()
+            relievers_used.append(sim.team1_current_pitcher_name)
+        self.assertGreater(
+            len(set(relievers_used)),
+            1,
+            "Bullpen usage is identical across games; expected different first relievers."
+        )
+
+    def test_play_by_play_avoids_engine_tells(self):
+        random.seed(2024)
+        sim = BaseballSimulator(self.home, self.away)
+        pitcher = sim.team2_pitcher_stats[sim.team2_current_pitcher_name]
+        batter = sim.team1_lineup[0]
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            sim._simulate_at_bat(batter, pitcher)
+        log = buffer.getvalue()
+
+        self.assertNotIn("In play ->", log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_examples.py
+++ b/update_examples.py
@@ -1,0 +1,23 @@
+"""Regenerate the checked-in example game logs.
+
+Run `python update_examples.py` from the repository root to rebuild the
+example logs in the ``examples`` directory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from example_games import EXAMPLE_GAMES, EXAMPLES_DIR
+
+
+def main() -> None:
+    EXAMPLES_DIR.mkdir(parents=True, exist_ok=True)
+    for index, game in enumerate(EXAMPLE_GAMES, start=1):
+        output = game.render()
+        path = EXAMPLES_DIR / f"game_{index:02d}.txt"
+        path.write_text(output, encoding="utf-8")
+        print(f"Wrote {path.relative_to(Path.cwd())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rewrite the README to describe the modern simulator entry point and available CLI options
- document the deterministic example catalog, snapshot test, and update script for regenerating logs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e169e864e4832ca7c6aa31ba5ae45e